### PR TITLE
Draft Release By Tag

### DIFF
--- a/DraftReleaseByTag/README.md
+++ b/DraftReleaseByTag/README.md
@@ -1,0 +1,28 @@
+# Fetch Draft Release ID using Tag
+
+### Purpose
+During the workflow creating a Draft release is necessary, but there is no simple method to return it.
+
+### Input Parameters
+* TAG - Tag of the Release you require
+* TOKEN - Token 
+
+### Outputs
+* ID - ID of the found release
+
+### Example
+```       
+       - name: Check out the repo
+         uses: actions/checkout@v2
+
+       - name: Tests
+         id: tag_version
+         uses: DFE-Digital/github-actions/DraftReleaseByTag@GetIntoTeaching/DraftReleaseByTag 
+         with:
+           TAG: x1
+           TOKEN: ${{secrets.ACTIONS_API_ACCESS_TOKEN}}
+       
+       - name: Print
+         run:  echo ${{steps.tag_version.outputs.release_id}}
+
+```

--- a/DraftReleaseByTag/action.yml
+++ b/DraftReleaseByTag/action.yml
@@ -1,0 +1,36 @@
+name: Select Draft Release Data 
+description: Passing in a Tag , this action will provide the ID of the Release  
+inputs:
+  TAG:
+    description: 'The TAG that you want to find Release for'
+    required:    true
+  TOKEN:
+    description: 'GITHUB Token with access to the draft release'
+    required:    true
+outputs:
+  release_id: 
+     description: The Release ID
+     value: ${{ steps.release.outputs.release_id }}
+  found: 
+     description: Found or Not Found 
+     value: ${{ steps.release.outputs.found }}
+runs:
+  using: composite
+  steps:
+       - name: Find Release
+         shell: bash
+         id: release
+         run: |
+           NUM=$( curl -s --header "Authorization: token ${{inputs.TOKEN}}"  \
+                       -X GET "https://api.github.com/repos/${{github.repository}}/releases" | \
+                       jq '.[] | select( .tag_name=="${{inputs.TAG}}" ) | .id')
+
+           if [[ -z ${NUM} ]] ;
+           then
+              echo "${{inputs.TAG}} not found"
+              echo ::set-output name=found::0
+           else
+              echo "${{inputs.TAG}} found id is ${NUM}"
+              echo ::set-output name=release_id::"${NUM}"
+              echo ::set-output name=found::1
+           fi


### PR DESCRIPTION
There is no method to get draft releases, so by using this code we can
create a draft release earlier in the pipeline and when we are ready we
can convert it to a published release.

This code is used to find the draft release using the API. You need to
pass in a GITHUB_TOKEN with access to the repository because draft
releases are usually kept private.