### PR TITLE
Add target-commit-sha

### DIFF
--- a/DraftReleaseByTag/README.md
+++ b/DraftReleaseByTag/README.md
@@ -10,9 +10,10 @@ make it available.
 * TOKEN - GITHUB Token 
 
 ### Outputs
-* release_id - ID of the found release
+* release_id - ID of the found release or NULL if not found
 * release_name - Name of the release
 * release_body - Body text of the release
+* release_sha  - Target Commit SHA of the Release
 * found - 1 or 0 depending on whether the release was found ( depreciated )
 
 ### Example
@@ -28,6 +29,7 @@ make it available.
            TOKEN: ${{secrets.ACTIONS_API_ACCESS_TOKEN}}
        
        - name: Print
+         if:   steps.tag_version.outputs.release_id 
          run:  |
                echo ID ${{steps.tag_version.outputs.release_id}}
                echo NAME ${{steps.tag_version.outputs.release_name}}

--- a/DraftReleaseByTag/action.yml
+++ b/DraftReleaseByTag/action.yml
@@ -17,8 +17,11 @@ outputs:
   release_body: 
      description: The Release Body
      value: ${{ steps.release.outputs.release_body }}
+  release_sha: 
+     description: The Release Target Commit SHA
+     value: ${{ steps.release.outputs.release_sha}}   
   found: 
-     description: Found or Not Found 
+     description: Found or Not Found (depriciated)
      value: ${{ steps.release.outputs.found }}
 runs:
   using: composite
@@ -35,11 +38,13 @@ runs:
            if [[ -z ${NUM} ]] ;
            then
               echo "${{inputs.TAG}} not found"
+              echo ::set-output name=release_id::""
               echo ::set-output name=found::0
            else
               echo "${{inputs.TAG}} found id is ${NUM}"
               echo ::set-output name=release_body::$( echo ${JSON} | tr '\r\n' ' ' | jq -r '.body')
               echo ::set-output name=release_name::$( echo ${JSON} | tr '\r\n' ' ' | jq -r '.name')
+              echo ::set-output name=release_sha::$(  echo ${JSON} | tr '\r\n' ' ' | jq -r '.target_commitish'
               echo ::set-output name=release_id::"${NUM}"
               echo ::set-output name=found::1
            fi

--- a/DraftReleaseByTag/action.yml
+++ b/DraftReleaseByTag/action.yml
@@ -21,7 +21,7 @@ outputs:
      description: The Release Target Commit SHA
      value: ${{ steps.release.outputs.release_sha}}   
   found: 
-     description: Found or Not Found (depriciated)
+     description: Found or Not Found (deprecated)
      value: ${{ steps.release.outputs.found }}
 runs:
   using: composite
@@ -44,7 +44,7 @@ runs:
               echo "${{inputs.TAG}} found id is ${NUM}"
               echo ::set-output name=release_body::$( echo ${JSON} | tr '\r\n' ' ' | jq -r '.body')
               echo ::set-output name=release_name::$( echo ${JSON} | tr '\r\n' ' ' | jq -r '.name')
-              echo ::set-output name=release_sha::$(  echo ${JSON} | tr '\r\n' ' ' | jq -r '.target_commitish'
+              echo ::set-output name=release_sha::$(  echo ${JSON} | tr '\r\n' ' ' | jq -r '.target_commitish' )
               echo ::set-output name=release_id::"${NUM}"
               echo ::set-output name=found::1
            fi


### PR DESCRIPTION
This change will add the target-commit-sha to the output of the release query.
Thus making it useful in Manual releases, and remove duplicate code