### PR TITLE
Create CF CLI and Postgres client actions

### DIFF
--- a/install-postgres-client/README.md
+++ b/install-postgres-client/README.md
@@ -1,0 +1,44 @@
+## Usage
+
+The typical setup for install-postgres-client involves adding a job step using `DFE-Digital/github-actions/install-postgres-client@master`.
+
+      - name: install-postgres-client
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+
+```diff
+name: Main
+
+on: push
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
++     - name: install-postgres-client
++       uses: DFE-Digital/github-actions/install-postgres-client@master
+```
+
+### Version
+
+You can also specify a particular version of the Postgres Client (defaults to `11`) with `jobs.<job_id>.steps.with.version`.
+
+```diff
+name: Main
+
+on: push
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
++     - name: install-postgres-client
++       uses: DFE-Digital/github-actions/install-postgres-client@master
++       with:
++         version: '12'
+```
+
+See [https://www.postgresql.org/download/linux/ubuntu/](https://www.postgresql.org/download/linux/ubuntu/) for a list of supported versions

--- a/install-postgres-client/action.yml
+++ b/install-postgres-client/action.yml
@@ -1,0 +1,21 @@
+name: Install Postgres client
+description: Install Postgres client
+inputs:
+  version:
+    description: 'Postgres version'
+    required:    true
+    default:     '11'
+runs:
+  using: composite
+  steps:
+  - name: Install Postgres client
+    shell: bash
+    id: install_postgres_client
+    run: |
+      wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+      RELEASE=$(lsb_release -cs)
+      echo "deb http://apt.postgresql.org/pub/repos/apt/ ${RELEASE}"-pgdg main | sudo tee  /etc/apt/sources.list.d/pgdg.list
+      cat /etc/apt/sources.list.d/pgdg.list
+      sudo apt-get update
+      sudo apt-get install -y postgresql-client-"${{inputs.version}}"
+      psql --version

--- a/install-postgres-client/action.yml
+++ b/install-postgres-client/action.yml
@@ -2,9 +2,9 @@ name: Install Postgres client
 description: Install Postgres client
 inputs:
   version:
-    description: 'Postgres version'
-    required:    true
-    default:     '11'
+    description: Postgres version
+    required: true
+    default: '11'
 runs:
   using: composite
   steps:

--- a/setup-cf-cli/README.md
+++ b/setup-cf-cli/README.md
@@ -1,0 +1,15 @@
+## Setup Cloud Foundry CLI
+Installs the Cloud Foundry CLI and logs the specified user into `CF_SPACE_NAME`.
+### Usage
+```yml
+ - uses: DFE-Digital/github-actions/setup-cf-cli@master
+   with:
+     CF_USERNAME: ${{ secrets.CF_USERNAME }}
+     CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+     CF_SPACE_NAME: bat-qa # required
+     # Optional inputs
+     CF_CLI_VERSION: v7 # default v7, allowed values: v6 or v7
+     CF_ORG_NAME: dfe # default
+     CF_API_URL:  https://api.london.cloud.service.gov.uk # default
+     INSTALL_CONDUIT: true # default: false
+```

--- a/setup-cf-cli/action.yml
+++ b/setup-cf-cli/action.yml
@@ -1,0 +1,57 @@
+name: Setup the Cloud Foundry CLI
+description: Step to install the cloud foundry cli on the agent.
+inputs:
+  CF_USERNAME:
+    description: Username to login to the PaaS space
+    required: true
+  CF_PASSWORD:
+    description: Password of the user to login to the PaaS space
+    required: true
+  CF_SPACE_NAME:
+    description: Name of the PaaS space to set the target context
+    required: true
+  CF_ORG_NAME:
+    description: Name of the PaaS organisation 
+    required: false
+    default: dfe
+  CF_API_URL:
+    description: PaaS API endpoint, default https://api.london.cloud.service.gov.uk
+    required: false
+    default: https://api.london.cloud.service.gov.uk
+  CF_CLI_VERSION:
+    description: Version of the CLI, allowed values v6 or v7, default v7
+    required: false
+    default: v7
+  INSTALL_CONDUIT:
+    description: Set to true to install the cf conduit extension
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps: 
+    - name : Install cf client
+      shell: bash
+      env:
+        CF_CLI_DOWNLOAD_URL: https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github&version=${{ inputs.CF_CLI_VERSION }}
+      run: |
+        echo "::group:: Download cf CLI"
+        curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
+        cf version
+        echo "::endgroup::"
+
+        if [ "${{ inputs.INSTALL_CONDUIT }}" == "true" ]
+        then
+          echo "::group:: Install Plugins"
+          cf install-plugin conduit -f
+          echo "::endgroup::"
+        fi
+
+    - name:  cf login
+      shell: bash
+      run: |
+        cf api ${{ inputs.CF_API_URL }}
+        cf auth
+        cf target -o ${{ inputs.CF_ORG_NAME }} -s ${{ inputs.CF_SPACE_NAME }}
+      env:
+        CF_USERNAME: ${{ inputs.CF_USERNAME }}
+        CF_PASSWORD: ${{ inputs.CF_PASSWORD }}


### PR DESCRIPTION
Per TEVA-1937, created custom actions to allow re-usable:
- installation of CloudFoundry CLI
- installation of Postgres client
Both allow specifying a version. CF CLI allows specifying a release.
To be merged before TEVA-1414, which uses the custom actions

Successful run shown against a temp commit, invoking the actions from a branch, and targeting the `teaching-vacancies-review` space: https://github.com/DFE-Digital/teaching-vacancies/runs/1786168712?check_suite_focus=true