### PR TITLE
Users to Avoid

### DIFF
--- a/CopyPRtoRelease/README.md
+++ b/CopyPRtoRelease/README.md
@@ -7,6 +7,7 @@ Copy the PR body to the Release body
 * `PR_NUMBER`  -  Pull Request number from which you want to extract the body from
 * `RELEASE_ID` -  Release ID which you want to update
 * `TOKEN`      -  GITHUB TOKEN
+* `USERS_TO_AVOID` - Optional list of users.
 
 ### Example
 ```       
@@ -21,3 +22,9 @@ Copy the PR body to the Release body
          TOKEN: ${{secrets.GITHUB_TOKEN}}
                     
 ```
+
+## Users to Avoid 
+This is an optional list of users, which defaults to snyk and dependabot. 
+
+When a PR is chosen that was created by Dependabot or Snyk there is often a lot of text and attachments, so rather than choose the body, we just display the title.
+

--- a/CopyPRtoRelease/action.yml
+++ b/CopyPRtoRelease/action.yml
@@ -10,6 +10,10 @@ inputs:
   TOKEN:
     description: 'GitHub Token'
     required:    true
+  USERS_TO_AVOID:
+    description: 'List of Users to restrict output to just title'
+    required:    false
+    default:     "snyk-bot, dependabot[bot]"
 runs:
   using: composite
   steps:
@@ -21,6 +25,15 @@ runs:
        - name: Copy PR to Release
          shell: bash
          run: |
-              BODY=$(curl -s -X GET -H "Authorization: token ${{inputs.TOKEN}}" "https://api.github.com/repos/${{github.repository}}/pulls/${{inputs.PR_NUMBER}}" | jq -r ".body" )
+              PULL=$(curl -s -X GET -H "Authorization: token ${{inputs.TOKEN}}" "https://api.github.com/repos/${{github.repository}}/pulls/${{inputs.PR_NUMBER}}" )
+              USER=$( echo ${PULL} | jq -r ".user.login" )
+              echo "User is ${USER}"
+              if  grep -Fq "$USER" <<< "${{inputs.USERS_TO_AVOID}}" ; then 
+                   echo "${USER} is in list"
+                   BODY=$( echo ${PULL} | jq -r ".title" )
+              else
+                   echo "${USER} is not in list"
+                   BODY=$( echo ${PULL} | jq -r ".body" )
+              fi
               jo body="${BODY}" > tempfile
-              curl -0 -X PATCH -H "Authorization: token ${{inputs.TOKEN}}" https://api.github.com/repos/${{github.repository}}/releases/${{inputs.RELEASE_ID}} --data-binary @tempfile
+              curl -s -0 -X PATCH -H "Authorization: token ${{inputs.TOKEN}}" https://api.github.com/repos/${{github.repository}}/releases/${{inputs.RELEASE_ID}} --data-binary @tempfile


### PR DESCRIPTION
# [Depeandabot PRs are not to Alert when Published](https://trello.com/c/R9zCMKl5/1461-depeandabot-prs-are-not-to-alert-when-published)

When a PR is created by Snyk or Dependabot quite a lot of text is provided, that our community are not interested in and it floods our slack channels. They are happy to see the title of the PR instead.

This change allows a list of users to be passed in, which if the PR is created by one of those users the title is chosen rather than the body.

The defaults Snyk and Dependabot