### PR TITLE
Run tests on pull requests against main as well as master

### DIFF
--- a/.github/workflows/test-setup-environment-variables.yml
+++ b/.github/workflows/test-setup-environment-variables.yml
@@ -3,12 +3,13 @@ name: Test Setup Environment Variables
 on:
   pull_request:
     branches:
+      - main
       - master
     paths:
-    - 'set-up-environment/**'  
+    - 'set-up-environment/**'
   push:
     paths:
-    - 'set-up-environment/**'    
+    - 'set-up-environment/**'
 
 jobs:
   set-up-environment:
@@ -21,7 +22,7 @@ jobs:
         uses: ./set-up-environment
         with:
           var_file: .github/env.yml
-                         
+
       - name: Print Environment Variables
         run:  |
           echo TEAM_NAME=${{ env.TEAM_NAME }}

--- a/.github/workflows/test-validate-key-vault-secrets.yml
+++ b/.github/workflows/test-validate-key-vault-secrets.yml
@@ -3,6 +3,7 @@ name: Test Validate KeyVault Secrets
 on:
   pull_request:
     branches:
+      - main
       - master
     paths:
     - 'validate-key-vault-secrets/**'
@@ -19,7 +20,7 @@ jobs:
 
       - uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}        
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Validate Key Vault Secrets
         uses: ./validate-key-vault-secrets


### PR DESCRIPTION
Apply will be deprecating `master` and moving to `main`. 
In order to enable that transition, we need to ensure that the github actions support any pull requests against `main`.

I think these are the only changes required and they should not impact any other projects.