### PR TITLE
Fix bug linking Trello cards when PR description contains quotation

### DIFF
--- a/AddTrelloComment/action.yml
+++ b/AddTrelloComment/action.yml
@@ -22,7 +22,7 @@ runs:
         id: trello-id
         run: |
             require "json" 
-            body = "${{ inputs.CARD }}" 
+            body = %(${{ inputs.CARD }})
             if m = body.match(%r{https://trello.com/c/([a-zA-Z0-9]+)}) 
                puts "::set-output name=id::#{m[1]}" 
             end


### PR DESCRIPTION
If the PR description contains a quotation the GitHub Action to link the Trello card will fail. This is often the case for descriptions that contain images, for example:

```
<img src="http://domain.com/image.png">
```

This is interpolated into the step as the following, which is incorrectly escaped:

```
body = "<img src="http://domain.com/image.png">"
```

We should be able to get around this by using a percent string (meaning it will handle unescaped double and single quotations):

```
body = %(<img src="http://domain.com/image.png">)
```