### PR TITLE
Make release_body output JSON

### DIFF
--- a/DraftReleaseByTag/action.yml
+++ b/DraftReleaseByTag/action.yml
@@ -39,7 +39,7 @@ runs:
                $myTag = $json.commit
 
                Write-Output "release_body<<$($myDelimiter)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-               Write-Output "$($myTag.message)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+               Write-Output "$($myTag.message | ConvertTo-Json -Compress)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
                Write-Output "$($myDelimiter)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
                Write-Output "release_name=No release details master commit" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -51,7 +51,7 @@ runs:
                Write-Output "${{inputs.TAG}} tag found, using..."
 
                Write-Output "release_body<<$($myDelimiter)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-               Write-Output "$($myTag.body)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+               Write-Output "$($myTag.body | ConvertTo-Json -Compress)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
                Write-Output "$($myDelimiter)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
                Write-Output "release_name=$($myTag.name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append


### PR DESCRIPTION
The old DraftReleaseByTag output the release_body in a JSON format. The recent update did not include this. Updating the action to fix downstream formatting issues.