### PR TITLE
700 update set output usage add trello comment

### DIFF
--- a/AddTrelloComment/action.yml
+++ b/AddTrelloComment/action.yml
@@ -12,34 +12,35 @@ inputs:
     required: true
   MESSAGE:
     description: Message
-    required: true    
+    required: true
 runs:
   using: composite
-  steps:    
-      
-      - name: Extract Trello URL
-        shell: ruby -- {0}
-        id: trello-id
-        run: |
-            require "json" 
-            body = %(${{ inputs.CARD }})
-            if m = body.match(%r{https://trello.com/c/([a-zA-Z0-9]+)}) 
-               puts "::set-output name=id::#{m[1]}" 
-            end
-            
-      - name: Link to Trello card
-        shell: bash
-        run: |
-            if [ ! -z "${{ steps.trello-id.outputs.id }}" ]
-            then
-               curl \
-                 --silent \
-                 --output /dev/null \
-                 --show-error \
-                 --fail \
-                 --request POST \
-                 --url 'https://api.trello.com/1/cards/${{ steps.trello-id.outputs.id }}/actions/comments' \
-                 --data-urlencode "key=${{ inputs.TRELLO-KEY }}" \
-                 --data-urlencode "token=${{ inputs.TRELLO-TOKEN }}" \
-                 --data-urlencode "text=${{ inputs.MESSAGE}}"
-            fi
+  steps:
+    - name: Extract Trello URL
+      shell: ruby -- {0}
+      id: trello-id
+      run: |
+        require "json"
+        body = %(${{ inputs.CARD }})
+        if m = body.match(%r{https://trello.com/c/([a-zA-Z0-9]+)})
+          open(ENV['GITHUB_OUTPUT'], 'a') { |f|
+            f.puts "id=#{m[1]}"
+          }
+        end
+
+    - name: Link to Trello card
+      shell: bash
+      run: |
+        if [ ! -z "${{ steps.trello-id.outputs.id }}" ]
+        then
+           curl \
+             --silent \
+             --output /dev/null \
+             --show-error \
+             --fail \
+             --request POST \
+             --url 'https://api.trello.com/1/cards/${{ steps.trello-id.outputs.id }}/actions/comments' \
+             --data-urlencode "key=${{ inputs.TRELLO-KEY }}" \
+             --data-urlencode "token=${{ inputs.TRELLO-TOKEN }}" \
+             --data-urlencode "text=${{ inputs.MESSAGE}}"
+        fi


### PR DESCRIPTION
Context
The set-output command is being deprecated and needs updating as per the [changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Changes
- Format using vscode extension
- Update the set-output usage to use ruby append file

Testing
- https://github.com/DFE-Digital/schools-experience/actions/runs/3525614567/jobs/5912548764