### PR TITLE
Set SNYK_TOKEN environment variable

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -89,7 +89,7 @@ runs:
       uses: snyk/actions/docker@master
       if: inputs.snyk-token != ''
       env:
-        snyk_token: ${{ inputs.snyk-token }}
+        SNYK_TOKEN: ${{ inputs.snyk-token }}
       with:
         image: ${{ inputs.docker-repository }}:${{ env.IMAGE_TAG }}
         args: --file=${{ inputs.dockerfile-path }} --severity-threshold=high --exclude-app-vulns


### PR DESCRIPTION
It looks like the environment variable has to be in all capital letters for it to work.

Example failing build: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/5424481103/jobs/9863897446?pr=1531
Example working build: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/5424624084/jobs/9864245409?pr=1531