### PR TITLE
context parameter added

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -12,7 +12,7 @@ Optionally (recommended) scan the image for vulnerabilities.
 - `snyk-token`: Snyk token for image vulnerability scanning (Default = none)
 - `reuse-cache`: Use previously built docker image layers to improve build time. Set to false to refresh image (Default = true)
 - `dockerfile-path`: Relative path to the Dockerfile (Default = ./Dockerfile)
-
+- `context`: Path used as file context for Docker. If not set, an empty git repository is initialised using the same git reference as the workflow.
 ## Outputs
 - `tag`: Tag uniquely generated for this build (Currently long commit SHA)
 - `image`: Reference to the built image suitable for use by Kubernetes (the docker repository combined with the tag)

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -17,6 +17,10 @@ inputs:
   dockerfile-path:
     description: Relative path to the Dockerfile (Default = ./Dockerfile)
     default: ./Dockerfile
+  context:
+    description: Path used as file context for Docker. If not set, an empty git repository is initialised using the same git reference as the workflow.
+    default: ""
+    type: string
 
 outputs:
   tag:
@@ -74,6 +78,7 @@ runs:
           type=registry,ref=${{ inputs.docker-repository }}:${{ env.BRANCH_TAG }}
         build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
         file: ${{ inputs.dockerfile-path }}
+        context: ${{ inputs.context }}
 
     - name: Build docker image without reusing cache
       uses: docker/build-push-action@v4
@@ -87,6 +92,7 @@ runs:
         cache-to: type=inline
         build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
         file: ${{ inputs.dockerfile-path }}
+        context: ${{ inputs.context }}
 
     - name: Run Snyk to check Docker image for vulnerabilities
       uses: snyk/actions/docker@master


### PR DESCRIPTION
## Context
Added optional parameter context, By setting value "." , docker/build-push-action will not pull git , it will use existing context.

## Changes proposed in this pull request
 Optional parameter **context** added

## Guidance to review
  Without context parameter, the action will pull like this 
```
          #1 [internal] load git source https://github.com/DFE-Digital/technical-guidance.git#refs/pull/188/merge
          #1 0.043 Initialized empty Git repository in /var/lib/docker/overlay2/d5jvo1twwso02k0m05r5zo9g4/di
```
By adding a context parameter with value "." , you will not see  **Initialized empty Git** 
 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
