### PR TITLE
Make docker repository optional in build-docker-image

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -1,18 +1,22 @@
 # Build docker image
 
-Build the docker image, with or without cache and push to the Github container registry. It creates 2 tags:
+Build the docker image, with or without cache and push to the Github container registry. If the package does not exist yet, it will create it and
+configure permissions and visibility automatically. For more information, read the [Github documentation](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions).
+
+It creates 2 tags:
 - Commit SHA to identify this build uniquely
 - Branch name to allow reusing the cached layers from the registry
 
-Optionally (recommended) scan the image for vulnerabilities.
+Optionally (recommended) scan the image for vulnerabilities using [Snyk](https://snyk.io/).
 
 ## Inputs
-- `docker-repository`: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers (Required)
-- `github-token`: Default Github token retrieved via secrets.GITHUB_TOKEN or PAT with permission to the repository (Required)
+- `github-token`: Default Github token retrieved via secrets. GITHUB_TOKEN or PAT with permission to the repository (Required)
 - `snyk-token`: Snyk token for image vulnerability scanning (Default = none)
 - `reuse-cache`: Use previously built docker image layers to improve build time. Set to false to refresh image (Default = true)
 - `dockerfile-path`: Relative path to the Dockerfile (Default = ./Dockerfile)
-- `context`: Path used as file context for Docker. If not set, an empty git repository is initialised using the same git reference as the workflow.
+- `context`: Path used as file context for Docker. If not set, the git repository is cloned using the same git reference as the workflow and used as context.
+- `docker-repository`: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers. Defaults to current Github repository name.
+
 ## Outputs
 - `tag`: Tag uniquely generated for this build (Currently long commit SHA)
 - `image`: Reference to the built image suitable for use by Kubernetes (the docker repository combined with the tag)
@@ -23,6 +27,5 @@ Optionally (recommended) scan the image for vulnerabilities.
 - name: Build and push docker image
   uses: DFE-Digital/github-actions/build-docker-image@master
   with:
-    docker-repository: ghcr.io/dfe-digital/teacher-pay-calculator
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -3,8 +3,8 @@ description: Build a docker image and push it to Github container registry
 
 inputs:
   docker-repository:
-    description: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers (Required)
-    required: true
+    description: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers. Defaults to current Github repository name.
+    default: ghcr.io/${{ github.repository }}
   github-token:
     description: Default Github token retrieved via secrets.GITHUB_TOKEN or PAT with permission to the repository (Required)
     required: true
@@ -18,7 +18,7 @@ inputs:
     description: Relative path to the Dockerfile (Default = ./Dockerfile)
     default: ./Dockerfile
   context:
-    description: Path used as file context for Docker. If not set, an empty git repository is initialised using the same git reference as the workflow.
+    description: Path used as file context for Docker. If not set, the git repository is cloned using the same git reference as the workflow and used as context.
     default: ""
     type: string
 
@@ -33,6 +33,12 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Ensure docker repository is lowercase
+      shell: pwsh
+      run: |
+        $DockerRepository = "${{ inputs.docker-repository }}".ToLower()
+        "DOCKER_REPOSITORY=$DockerRepository" | Out-File -FilePath $env:GITHUB_ENV -Append
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -67,26 +73,28 @@ runs:
       if: inputs.reuse-cache
       with:
         tags: |
-          ${{ inputs.docker-repository }}:${{ env.IMAGE_TAG }}
-          ${{ inputs.docker-repository }}:${{ env.BRANCH_TAG }}
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
         push: false
         load: true
         cache-to: type=inline
         cache-from: |
-          type=registry,ref=${{ inputs.docker-repository }}:main
-          type=registry,ref=${{ inputs.docker-repository }}:${{ env.IMAGE_TAG }}
-          type=registry,ref=${{ inputs.docker-repository }}:${{ env.BRANCH_TAG }}
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:main
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
         build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
         file: ${{ inputs.dockerfile-path }}
         context: ${{ inputs.context }}
+        labels: |
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
     - name: Build docker image without reusing cache
       uses: docker/build-push-action@v4
       if: ${{! inputs.reuse-cache}}
       with:
         tags: |
-          ${{ inputs.docker-repository }}:${{ env.IMAGE_TAG }}
-          ${{ inputs.docker-repository }}:${{ env.BRANCH_TAG }}
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
         push: false
         load: true
         cache-to: type=inline
@@ -100,9 +108,9 @@ runs:
       env:
         SNYK_TOKEN: ${{ inputs.snyk-token }}
       with:
-        image: ${{ inputs.docker-repository }}:${{ env.IMAGE_TAG }}
+        image: ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
         args: --file=${{ inputs.dockerfile-path }} --severity-threshold=high --exclude-app-vulns
 
-    - name: Push ${{ inputs.docker-repository }}:${{ env.IMAGE_TAG }} image to registry
+    - name: Push ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }} image to registry
       shell: bash
-      run: docker image push --all-tags ${{ inputs.docker-repository }}
+      run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}


### PR DESCRIPTION
## Context
Make it easier to adopt this action by removing the need to pass in the argument

## Changes proposed in this pull request
Default the docker repository name to the Github repository

## Guidance to review
See it in action: https://github.com/DFE-Digital/technical-guidance/actions/runs/7105521974/job/19342894406

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
