### PR TITLE
[925] set-kubelogin-environment action

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Welcome to the central repository for GitHub Actions at the DfE!
 * [install-postgres-client](install-postgres-client)
 * [SendToLogit](SendToLogit)
 * [set-arm-environment-variables](set-arm-environment-variables)
+* [set-kubelogin-environment](set-kubelogin-environment)
 * [set-up-environment](set-up-environment)
 * [setup-cf-cli](setup-cf-cli)
 * [turnstyle](turnstyle)

--- a/set-kubelogin-environment/README.md
+++ b/set-kubelogin-environment/README.md
@@ -1,0 +1,18 @@
+# Set kubelogin environment
+
+[kubelogin](https://azure.github.io/kubelogin/) is required for authentication to AKS cluster with Azure RBAC. It relies on environment variables to use a service principal.
+
+This action uses [set-arm-environment-variables](../set-arm-environment-variables/README.md) to sets the environment variables suitable for running Terraform, adds the kubelogin specific variables, and sets up kubelogin itself.
+
+## Inputs
+
+- `azure-credentials` - A JSON string containing service principal credentials.
+
+## Example
+
+```yaml
+- name: Set kubelogin environment
+  uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+  with:
+    azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+```

--- a/set-kubelogin-environment/action.yaml
+++ b/set-kubelogin-environment/action.yaml
@@ -1,0 +1,26 @@
+name: Set ARM variables and kubelogin
+description: Sets the environment variables suitable for running Terraform and kubelogin to use with Azure RBAC enabled clusters
+
+inputs:
+  azure-credentials:
+    description: A JSON string containing service principle credentials.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set ARM variables
+      uses: DFE-Digital/github-actions/set-arm-environment-variables@925-rbac-migrate-clusters-development
+      with:
+        azure-credentials: ${{ inputs.azure-credentials }}
+
+    - name: Set up kubelogin
+      uses: azure/use-kubelogin@v1
+      with:
+        kubelogin-version: 'v0.0.33'
+
+    - name: Set kubelogin SPN variables
+      shell: bash
+      run: |
+        echo "AAD_SERVICE_PRINCIPAL_CLIENT_ID=$ARM_CLIENT_ID" >> $GITHUB_ENV
+        echo "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET=$ARM_CLIENT_SECRET" >> $GITHUB_ENV


### PR DESCRIPTION
## Context
Simplify migration to Azure RBAC enabled clusters. This can replace the `set-arm-environment-variables` action to configure kubelogin as well.

## Changes proposed in this pull request
New action which calls set-arm-environment-variables then configures kubelogin for service principal authentication

## Guidance to review
Check PR https://github.com/DFE-Digital/register-trainee-teachers/pull/3949

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
