### PR TITLE
azure/use-kubelogin upgraded to 1.2

### DIFF
--- a/set-kubelogin-environment/action.yaml
+++ b/set-kubelogin-environment/action.yaml
@@ -15,7 +15,7 @@ runs:
         azure-credentials: ${{ inputs.azure-credentials }}
 
     - name: Set up kubelogin
-      uses: azure/use-kubelogin@v1
+      uses: azure/use-kubelogin@v1.2
       with:
         kubelogin-version: 'v0.0.33'
 


### PR DESCRIPTION
## Context
Deprecation warnings:
> Deploy Cluster (platform-test)
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: Azure/login@v1, azure/use-kubelogin@v1, azure/setup-kubectl@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The v1.2 version has node20 but the v1 tag was not updated. [Created an issue](https://github.com/Azure/use-kubelogin/issues/50) to fix the tag, but in the meantime, upgraded to the latest version of azure/use-kubelogin

## Changes proposed in this pull request
Updated action.yaml  azure/use-kubelogin version 1.2

## Guidance to review
Any Pipelines using this actions  should not show warning , Ex: teachers-services-cloud 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
