### PR TITLE
[1823] Make build-docker-image work for other event types

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -62,6 +62,13 @@ runs:
         echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
         echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
+    - name: Set environment variables (default event)
+      if: github.event_name != 'push' && github.event_name != 'pull_request'
+      shell: bash
+      run: |
+        echo "BRANCH_TAG=main" >> $GITHUB_ENV
+        echo "IMAGE_TAG=$(date +%s)" >> $GITHUB_ENV
+
     - name: Set tag output
       id: set-tag-output
       shell: bash

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -40,7 +40,7 @@ runs:
         "DOCKER_REPOSITORY=$DockerRepository" | Out-File -FilePath $env:GITHUB_ENV -Append
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -76,7 +76,7 @@ runs:
         echo "tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
     - name: Build docker image using cache
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       if: inputs.reuse-cache
       with:
         tags: |
@@ -96,7 +96,7 @@ runs:
           org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
     - name: Build docker image without reusing cache
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       if: ${{! inputs.reuse-cache}}
       with:
         tags: |


### PR DESCRIPTION
## Context
The tags are normally set based on branches and git sha when using push or pull_request events. It fails for workflow_dispatch or schedule events

## Changes proposed in this pull request
For other events like workflow_dispatch or schedule, branches and git sha are not relevant so we use a timestamp and main as default branch.

## Guidance to review
See successful run in Apply: https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/9100285983

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
