### PR TITLE
Introduce target for building a multi-stage build target

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -15,6 +15,7 @@ Optionally (recommended) scan the image for vulnerabilities using [Snyk](https:/
 - `reuse-cache`: Use previously built docker image layers to improve build time. Set to false to refresh image (Default = true)
 - `dockerfile-path`: Relative path to the Dockerfile (Default = ./Dockerfile)
 - `context`: Path used as file context for Docker. If not set, the git repository is cloned using the same git reference as the workflow and used as context.
+- `target`: The target stage to build of a multi-stage build
 - `docker-repository`: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers. Defaults to current Github repository name.
 
 ## Outputs

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -21,6 +21,8 @@ inputs:
     description: Path used as file context for Docker. If not set, the git repository is cloned using the same git reference as the workflow and used as context.
     default: ""
     type: string
+  target:
+    description: The target stage to build of a multi-stage build
 
 outputs:
   tag:
@@ -85,6 +87,7 @@ runs:
         build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
         file: ${{ inputs.dockerfile-path }}
         context: ${{ inputs.context }}
+        target: ${{ inputs.target }}
         labels: |
           org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
@@ -101,6 +104,7 @@ runs:
         build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
         file: ${{ inputs.dockerfile-path }}
         context: ${{ inputs.context }}
+        target: ${{ inputs.target }}
 
     - name: Run Snyk to check Docker image for vulnerabilities
       uses: snyk/actions/docker@master


### PR DESCRIPTION
## Context

We'd like to build and push a specific stage of a multi-stage build: https://docs.docker.com/build/building/multi-stage/#stop-at-a-specific-build-stage

## Changes proposed in this pull request

- Introduces a `target` input for the `build-docker-image` action

## Guidance to review

- Use this branch in another workflow action
- Test where both `target` is present, and where it isn't given (in which case the action will build and push whatever build stage is last in the `Dockerfile`)

```yml
- name: Build and push docker image
  uses: DFE-Digital/github-actions/build-docker-image@docker-build-target
  with:
    target: web
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
