### PR TITLE
Kubectl version updated to 1.27.9 to align with AKS

### DIFF
--- a/set-kubectl/action.yaml
+++ b/set-kubectl/action.yaml
@@ -7,4 +7,4 @@ runs:
     - name: Install kubectl
       uses: azure/setup-kubectl@v4
       with:
-        version: 'v1.27.7'
+        version: 'v1.27.9'


### PR DESCRIPTION
 ## Context
Kubectl version upgraded to 1.27.9 to align with AKS cluster version.

 
## Guidance to review
 Kubectl version upgraded to 1.27.9 to align with AKS cluster version.  

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
