### PR TITLE
SAST reusable workflow documentation and additional functionality

### DIFF
--- a/.github/workflows/reusable-workflow-sast.yml
+++ b/.github/workflows/reusable-workflow-sast.yml
@@ -62,7 +62,11 @@ on:
         type: string
         required: false
         default: continue
-
+      force_semgrep:
+        description: Force this workflow to use semgrep instead of codeql - codeql is the default option unless the repository is private, otherwise it falls back to semgrep.
+        type: boolean
+        required: false
+        default: false
     secrets:
       NUGET_AUTH_TOKEN:
         description: This is the token required for Nuget to authenticate to the packages repository via the nuget-source-url if you're using a private repository
@@ -75,9 +79,78 @@ on:
         required: false
 
 jobs:
-  run-codeql-sast:
-    name: CodeQL SAST
+  test-visibility:
+
+    name: Test repo visibility
     runs-on: ubuntu-latest
+
+    outputs:
+      visibility: ${{ steps.check-visibility.outputs.visibility }}
+
+    steps:
+
+      - name: Check repo visibility (GHAS currently not procured)
+        id: check-visibility
+        run: |
+          status_code=$(curl -s -o /dev/null -w "%{http_code}" https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }})
+          if [ $status_code -eq 200 ];
+          then
+            echo $status_code
+            visibility=public
+            echo "visibility=public" >> "$GITHUB_OUTPUT"
+          else
+            echo $status_code
+            echo "visibility=private" >> "$GITHUB_OUTPUT"
+            visibility=private
+          fi
+
+  semgrep:
+    name: semgrep-oss/scan
+    runs-on: ubuntu-latest
+
+    needs: test-visibility
+
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+
+    container:
+      # A Docker image with Semgrep installed. Do not change this.
+      image: semgrep/semgrep
+
+    if: ${{ (github.actor != 'dependabot[bot]') && (inputs.force_semgrep == true || needs.test-visibility.outputs.visibility == 'private') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Run the "semgrep scan" command on the command line of the docker image.
+      - run: semgrep scan --config auto --sarif --sarif-output=semgrep.sarif --force-color
+
+      - name: Name sarif outputs
+        id: name-sarifs
+        # service: This variable creates a new name with the owner and repo name, makes it lowercase and replaces any of the following with underscores: / . - <space> 
+        # epoch: This variable echos the time in epoch
+        # The final line contatenates the epoch and name and outputs it to the GitHub environment so it can be used by the upload-artifacts step - naming convention is strict to ensure we don't break any steps
+        # The reasoning for this is so that we have unique naming (required for the next step), and so CISD tooling can track and collect the data based on naming convention
+        run: |
+          service=$(echo ${{ github.repository_owner }}_${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]' | sed -e 's|/|_|g' -e 's|\.|_|g' -e 's| |_|g' -e 's|-|_|g')
+          epoch=$(echo $EPOCHSECONDS)
+          echo report_name=$epoch"_"$service >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:  
+            name: ${{ steps.name-sarifs.outputs.report_name }}
+            path: ${{ github.workspace }}/semgrep.sarif
+        # Quotas being met
+        continue-on-error: true
+
+  run-codeql-sast:
+    name: CodeQL SAST (public repos)
+    runs-on: ubuntu-latest
+
+    needs: test-visibility
+
     permissions:
       actions: read
       contents: read
@@ -89,13 +162,14 @@ jobs:
       matrix:
         location: ${{ fromJSON(inputs.dotnet_project_locations) }}
 
+    if: ${{ (github.actor != 'dependabot[bot]') && (needs.test-visibility.outputs.visibility == 'public' && inputs.force_semgrep == false) }}
     steps:
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
+        
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -144,24 +218,36 @@ jobs:
           ref: ${{ inputs.ref }}
           sha: ${{ inputs.sha }}
           output: './results'
+      
+      - name: Name sarif outputs
+        id: name-sarifs
+        run: |
+          service=$(echo ${{ github.repository_owner }}_${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]' | sed -e 's|/|_|g' -e 's|\.|_|g' -e 's| |_|g' -e 's|-|_|g')
+          epoch=$(echo $EPOCHSECONDS)
+          echo report_name=$epoch"_"$service >> "$GITHUB_OUTPUT"
+
 
       - name: Upload sarif artifact
         uses: actions/upload-artifact@v4
         with:
-          name: 'codeql-sarif-report'
+          name: '${{ steps.name-sarifs.outputs.report_name }}'
           path: '${{ github.workspace }}/results/*.sarif'
-          retention-days: ${{ inputs.retention_days }}
+          retention-days: 1
+        # Quotas being met
+        continue-on-error: true
         if: ${{ inputs.dotnet_project_locations == '["./"]' }}
 
       - name: Remove slashes
         id: remove-slashes
-        run: echo "report_name_suffix=$(echo ${{matrix.location}} | sed 's|/|-|g')" >> "$GITHUB_OUTPUT"
+        run: echo "report_name_prefix=$(echo ${{matrix.location}} | sed -e 's|/|_|g' -e 's|\.|_|g' -e 's| |_|g' -e 's|-|_|g')" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: 'codeql-sarif-report-${{ steps.remove-slashes.outputs.report_name_suffix }}'
+          name: '${{ steps.remove-slashes.outputs.report_name_prefix }}_${{ steps.name-sarifs.outputs.report_name }}'
           path: '${{ github.workspace }}/results/*.sarif'
           retention-days: 1
+        # Quotas being met
+        continue-on-error: true
         if: ${{ inputs.dotnet_project_locations != '["./"]' }}
 
 
@@ -173,27 +259,16 @@ jobs:
       security-events: write
       pull-requests: write
 
-    needs: [run-codeql-sast]
+    needs: [run-codeql-sast, test-visibility]
 
     env:
       CODEQL_AUTHENTICATION_PRIVATE_KEY: ${{ secrets.CODEQL_AUTHENTICATION_PRIVATE_KEY }}
 
+    if: ${{ needs.test-visibility.outputs.visibility == 'public' }}
     steps:
 
-      - name: Check repo visibility (GHAS currently not procured)
-        id: check-visibility
-        run: |
-          status_code=$(curl -s -o /dev/null -w "%{http_code}" https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }})
-          if [ $status_code -eq 200 ];
-          then
-            echo "visibility=public" >> "$GITHUB_OUTPUT"
-          else
-            echo "visibility=private" >> "$GITHUB_OUTPUT"
-          fi
-
-
       - uses: actions/create-github-app-token@v1
-        if: ${{ env.CODEQL_AUTHENTICATION_PRIVATE_KEY && steps.check-visibility.outputs.visibility == 'public' }}
+        if: ${{ env.CODEQL_AUTHENTICATION_PRIVATE_KEY }}
         id: app-token
         with:
           app-id: ${{ secrets.CODEQL_APP_ID }}
@@ -202,7 +277,7 @@ jobs:
 
 
       - name: Advance Security Compliance Action
-        if: ${{ env.CODEQL_AUTHENTICATION_PRIVATE_KEY && steps.check-visibility.outputs.visibility == 'public' }}
+        if: ${{ env.CODEQL_AUTHENTICATION_PRIVATE_KEY }}
         uses: advanced-security/policy-as-code@v2.7.3
         with:
           # Set the severity levels which to set the threshold. All previous 
@@ -218,7 +293,7 @@ jobs:
           # The owner/repo of where the policy is stored
           # This generally is primarily used for a single repository that defines 
           #  your organizations security policy
-          policy: pritchyspritch/dfe-github-actions
+          policy: DFE-Digital/github-actions
 
           # The path where the policy lives. This might be in either the current 
           #  repository or in a remote repository.

--- a/sast-reusable-workflow/README.md
+++ b/sast-reusable-workflow/README.md
@@ -1,18 +1,21 @@
-# CodeQL SAST Reusable Workflow
+# SAST Reusable Workflow
 
-Reusable workflows must be kept in the [.github/workflows](../.github/workflows) directory, find the CodeQL SAST reusable workflow at the link below: 
+Reusable workflows must be kept in the [.github/workflows](../.github/workflows) directory, find the SAST reusable workflow at the link below: 
 
-* [CodeQL SAST reusable workflow](../.github/workflows/reusable-workflow-codeql-sast.yml)
+* [CodeQL SAST reusable workflow](../.github/workflows/reusable-workflow-sast.yml)
 
-The workflow also utilises [GitHub Policy as Code](https://github.com/advanced-security/policy-as-code/), to allow teams to break builds where security issues are over SLA, to highlight where malicious typosquatting packages have been accidentally included in the build, and to raise Dependabot, CodeQL, Secret Scanning and Licensing issues in the pipeline. 
+The workflow also utilises [GitHub Policy as Code](https://github.com/advanced-security/policy-as-code/) for CodeQL scans, to allow teams to break builds where security issues are over SLA, to highlight where malicious typosquatting packages have been accidentally included in the build, and to raise Dependabot, CodeQL, Secret Scanning and Licensing issues in the pipeline. 
 
 Policy information can be found at [.github/policy-as-code](../.github/policy-as-code):
 * [The policy yaml file, showing SLAs for issues](../.github/policy-as-code/ghas-policy.yml)
 * [The typosquatting list, to ensure known malicious typosquat packages aren't included in builds](../.github/policy-as-code/typosquatting.txt)
 
+> [!WARNING]
+> DfE do not currently pay for GitHub Advanced Security, so this workflow runs CodeQL for SAST scans if the repository is public (as it's free for public repos). Otherwise, we will utilise semgrep open source SAST. The policy as code feature will also only work for CodeQL scans.
+
 ### Purpose
 1. Provide DfE services with an easy to use workflow for static code analysis, to improve the security and quality of code.
-2. To provide the ability to (optionally) stop deployments if security issues are found to be over SLA and to highlight issues in the pipeline found for CodeQL, Dependabot and GitHub Secret Scanning.
+2. To provide the ability to (optionally) stop deployments if security issues are found to be over SLA and to highlight issues in the pipeline found for CodeQL, Dependabot and GitHub Secret Scanning (only works for public repos).
 
 ### Input Parameters
 
@@ -29,17 +32,27 @@ Policy information can be found at [.github/policy-as-code](../.github/policy-as
 * `ref` - The fully-formed ref of the branch or tag that triggered the workflow run. If you're using a pull_request type closed, you may need to set this. Otherwise the default from github will be used.
 * `sha` - The commit SHA that triggered the workflow.
 * `policy_action` - The action to take if policy-as-code checks fail thresholds options: ['break', 'continue']
+* `force_semgrep` - Force this workflow to use semgrep instead of codeql - codeql is the default option unless the repository is private, otherwise it falls back to semgrep.
 
+### Secrets
+
+* `NUGET_AUTH_TOKEN` - This is the token required for Nuget to authenticate to the packages repository via the nuget-source-url (only required if you're using a private nuget repository).
+* `CODEQL_AUTHENTICATION_PRIVATE_KEY` - Private key used to authenticate as GitHub App.
+* `CODEQL_APP_ID` - The app ID of the GitHub App used to authenticate with GHAS compliance.
+
+> [!IMPORTANT]
+> In order for the compliance job to run, you must provide the `CODEQL_AUTHENTICATION_PRIVATE_KEY` and `CODEQL_APP_ID` secrets, they have been made available as organisation secrets, so you simply need to reference it in your workflow job.
+        
 ### Examples
 #### .NET
 ```
 jobs:
   run-codeql:
-    uses: DFE-Digital/github-actions/.github/workflows/reusable-workflow-codeql-sast.yml@master
+    uses: DFE-Digital/github-actions/.github/workflows/reusable-workflow-sast.yml@master
     with:
       language: 'csharp' 
       dotnet_project_locations: '["./"]' 
-      dotnet_version: '2.0.*' 
+      dotnet_version: '6.0.*' 
       policy_action: 'break'
       nuget-source-url: 'https://nuget.pkg.github.com/DfE-Digital/index.json' # only required if you're using a private nuget source
     secrets:
@@ -54,11 +67,11 @@ jobs:
 ```
 jobs:
   run-codeql:
-    uses: DFE-Digital/github-actions/.github/workflows/reusable-workflow-codeql-sast.yml@master
+    uses: DFE-Digital/github-actions/.github/workflows/reusable-workflow-sast.yml@master
     with:
       language: 'ruby' 
       policy_action: 'break'
-      queries: 'security-and-quality'
+      queries: 'security-extended'
     secrets:
       CODEQL_AUTHENTICATION_PRIVATE_KEY: ${{ secrets.CODEQL_AUTHENTICATION_PRIVATE_KEY }} 
 


### PR DESCRIPTION
Added documentation for GitHub Compliance App, and logic to allow semgrep in case repo is private or developer preference.

## Context
v1 of this workflow would not have worked for private repos due to licensing issues. 

## Changes proposed in this pull request
This version includes:
* checks to see if the repo is private which triggers semgrep instead of codeql
* the option to force semgrep if a team prefers it to codeql
* naming and uploading of artefacts so they can be picked up by the security teams reporting tools
* extra documentation to explain the compliance check, and how to ensure it runs in your pipeline
* the compliance job will now run so long as the repo is public, now that the app has been installed in this org and secrets are available

## Guidance to review
Successful run on test repo, shows build breaking due to security issues found outside of SLA policies: https://github.com/DFE-Digital/test-codeql/actions/runs/9909251763

## Checklist

- [X] I have performed a self-review of my code, including formatting and typos
- [X] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [X] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
