### PR TITLE
[1914] Fix backup-postgres and install-postgres-client for version 16

### DIFF
--- a/backup-postgres/README.md
+++ b/backup-postgres/README.md
@@ -9,7 +9,7 @@ Mainly designed to be used in DR and DR test procedures
 - `app-name`: Name of the aks app deployment (Required)
 - `cluster`: AKS cluster to use, test or production (Required)
 - `azure-credentials`: A JSON string containing service principle credentials (Required)
-- `backup-file`: Name of the backup file (Required)
+- `backup-file`: Name of the backup file. The file will be compressed and the .gz extension added to this name. (Required)
 
 ## Example
 
@@ -18,8 +18,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+
       - name: Backup postgres
         uses: DFE-Digital/github-actions/backup-postgres@master
         with:

--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -66,13 +66,13 @@ runs:
         az aks get-credentials --overwrite-existing -g ${{ env.cluster_rg }} -n ${{ env.cluster_name }}
         kubelogin convert-kubeconfig -l spn
         # install konduit
-        curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o bin/konduit.sh
-        chmod +x bin/konduit.sh
+        curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o ./konduit.sh
+        chmod +x ./konduit.sh
 
     - name: Create compressed backup for aks env database
       shell: bash
       run: |
-        bin/konduit.sh -t 7200 ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
+        ./konduit.sh -t 7200 ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
 
     - name: Set Connection String
       shell: bash

--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
       with:
-        version: 14
+        version: 16
 
     - name: Install kubectl
       uses: DFE-Digital/github-actions/set-kubectl@master

--- a/install-postgres-client/action.yml
+++ b/install-postgres-client/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: Postgres version
     required: true
-    default: '11'
+    default: '16'
 runs:
   using: composite
   steps:
@@ -12,6 +12,7 @@ runs:
     shell: bash
     id: install_postgres_client
     run: |
+      sudo apt-get --purge remove postgresql-client-14
       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
       RELEASE=$(lsb_release -cs)
       echo "deb http://apt.postgresql.org/pub/repos/apt/ ${RELEASE}"-pgdg main | sudo tee  /etc/apt/sources.list.d/pgdg.list
@@ -19,3 +20,4 @@ runs:
       sudo apt-get update
       sudo apt-get install -y postgresql-client-"${{inputs.version}}"
       psql --version
+      pg_dump --version

--- a/restore-postgres-backup/README.md
+++ b/restore-postgres-backup/README.md
@@ -18,8 +18,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+
       - name: Restore postgres backup
         uses: DFE-Digital/github-actions/restore-postgres-backup@master
         with:

--- a/restore-postgres-backup/action.yml
+++ b/restore-postgres-backup/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
       with:
-        version: 14
+        version: 16
 
     - name: Install kubectl
       uses: DFE-Digital/github-actions/set-kubectl@master

--- a/restore-postgres-backup/action.yml
+++ b/restore-postgres-backup/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: A JSON string containing service principle credentials.
     required: true
   backup-file:
-    description: Name of the backup file to restore
+    description: Name of the backup file to restore. Must include the .gz extension if the remote file has it.
     required: true
 
 runs:
@@ -65,8 +65,8 @@ runs:
         az aks get-credentials --overwrite-existing -g ${{ env.cluster_rg }} -n ${{ env.cluster_name }}
         kubelogin convert-kubeconfig -l spn
         # install konduit
-        curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o bin/konduit.sh
-        chmod +x bin/konduit.sh
+        curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o ./konduit.sh
+        chmod +x ./konduit.sh
 
     - name: Set Connection String
       shell: bash
@@ -88,7 +88,7 @@ runs:
       run: |
         COMPRESS=$( file --brief ${{ inputs.backup-file }} | grep -ic compressed || true )
         if [[ $COMPRESS -gt 0 ]]; then
-          bin/konduit.sh -i ${{ inputs.backup-file }} -c -t 7200 ${{ inputs.app-name }} -- psql
+          ./konduit.sh -i ${{ inputs.backup-file }} -c -t 7200 ${{ inputs.app-name }} -- psql
         else
-          bin/konduit.sh -i ${{ inputs.backup-file }} -t 7200 ${{ inputs.app-name }} -- psql
+          ./konduit.sh -i ${{ inputs.backup-file }} -t 7200 ${{ inputs.app-name }} -- psql
         fi


### PR DESCRIPTION
## Context
The action was failing for version 16, required for Claims
See: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/9910221790/job/27380095791

## Changes proposed in this pull request
- Delete conflicting default postgres client 14 before installing 16

Other improvements:
- Remove the need for existing `./bin` directory by downloading konduit.sh in the current directory

## Guidance to review
See sucessful runs:
- Backup: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/9910221790/job/27385133608
- Restore: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/actions/runs/9937920315/job/27449265757

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
