### PR TITLE
Allow backup of PTR server using backup-postgres

### DIFF
--- a/backup-postgres/README.md
+++ b/backup-postgres/README.md
@@ -10,6 +10,7 @@ Mainly designed to be used in DR and DR test procedures
 - `cluster`: AKS cluster to use, test or production (Required)
 - `azure-credentials`: A JSON string containing service principle credentials (Required)
 - `backup-file`: Name of the backup file. The file will be compressed and the .gz extension added to this name. (Required)
+- `ptr-db-server-name` : For use if backing up a point in time restored server (Optional)
 
 ## Example
 

--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -23,6 +23,9 @@ inputs:
   backup-file:
     description: Name of the backup file
     required: true
+  ptr-db-server-name:
+    description: Name of the PTR postgres server
+    required: false
 
 runs:
   using: composite
@@ -72,7 +75,11 @@ runs:
     - name: Create compressed backup for aks env database
       shell: bash
       run: |
-        ./konduit.sh -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
+        if [[ -n "${{ inputs.ptr-db-server-name }}" ]]; then
+          ./konduit.sh -s ${{ inputs.ptr-db-server-name }} -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
+        else
+          ./konduit.sh -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
+        fi
 
     - name: Set Connection String
       shell: bash


### PR DESCRIPTION
## Context
https://trello.com/c/Zkl78tQ5/1977-backup-ptr-database-using-github-action

Update backup-postgres github action so that a PTR postgres server can be backed up

## Changes proposed in this pull request
Add ptr-db-server-name to the github action, which will be invoked by konduit -s when specified as an input

## Guidance to review
backup of source server (s189d01-rtt-rv-pg)
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/10390616053

backup of PTR copy (s189d01-rtt-rv-pg-ptr)
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/10390757032 

## Before merge
remove 'for dev testing' commit before merge

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
