### PR TITLE
Update policy-as-code action and remove upload artifacts for codeql

### DIFF
--- a/.github/workflows/reusable-workflow-sast.yml
+++ b/.github/workflows/reusable-workflow-sast.yml
@@ -218,37 +218,6 @@ jobs:
           ref: ${{ inputs.ref }}
           sha: ${{ inputs.sha }}
           output: './results'
-      
-      - name: Name sarif outputs
-        id: name-sarifs
-        run: |
-          service=$(echo ${{ github.repository_owner }}_${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]' | sed -e 's|/|_|g' -e 's|\.|_|g' -e 's| |_|g' -e 's|-|_|g')
-          epoch=$(echo $EPOCHSECONDS)
-          echo report_name=$epoch"_"$service >> "$GITHUB_OUTPUT"
-
-
-      - name: Upload sarif artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: '${{ steps.name-sarifs.outputs.report_name }}'
-          path: '${{ github.workspace }}/results/*.sarif'
-          retention-days: 1
-        # Quotas being met
-        continue-on-error: true
-        if: ${{ inputs.dotnet_project_locations == '["./"]' }}
-
-      - name: Remove slashes
-        id: remove-slashes
-        run: echo "report_name_prefix=$(echo ${{matrix.location}} | sed -e 's|/|_|g' -e 's|\.|_|g' -e 's| |_|g' -e 's|-|_|g')" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: '${{ steps.remove-slashes.outputs.report_name_prefix }}_${{ steps.name-sarifs.outputs.report_name }}'
-          path: '${{ github.workspace }}/results/*.sarif'
-          retention-days: 1
-        # Quotas being met
-        continue-on-error: true
-        if: ${{ inputs.dotnet_project_locations != '["./"]' }}
 
 
   Compliance:
@@ -278,7 +247,7 @@ jobs:
 
       - name: Advance Security Compliance Action
         if: ${{ env.CODEQL_AUTHENTICATION_PRIVATE_KEY }}
-        uses: advanced-security/policy-as-code@v2.7.3
+        uses: advanced-security/policy-as-code@v2.8.0
         with:
           # Set the severity levels which to set the threshold. All previous 
           # severities are included so selecting 'error' also selects 'critical' and 


### PR DESCRIPTION
Update policy-as-code action and remove upload artifacts for codeql (no longer necessary for codeql).


## Changes proposed in this pull request
Includes two updates:
1. Update the policy as code action to the latest version.
2. Remove upload artifact steps for codeql as we are now retrieving data for that step via the github api. Semgrep still requires an artifact due to licensing issues with github.

## Checklist

- [X] I have performed a self-review of my code, including formatting and typos
- [X] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [X] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
