### PR TITLE
Add dependabot config to keep workflows up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,269 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (repo and reusable workflows): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/AddTrelloComment"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (AddTrelloComment): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/backup-postgres"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (backup-postgres): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/build-docker-image"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (build-docker-image): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/CheckServicePrincipal"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (CheckServicePrincipal): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/CopyPRtoRelease"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (CopyPRtoRelease): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+          
+  - package-ecosystem: "github-actions"
+    directory: "/DraftReleaseByTag"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (DraftReleaseByTag): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/GenerateReleaseFromSHA"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (GenerateReleaseFromSHA): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/install-postgres-client"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (install-postgres-client): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/ptr-postgres"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (ptr-postgres): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+          
+  - package-ecosystem: "github-actions"
+    directory: "/restore-postgres-backup"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (restore-postgres-backup): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/SendToLogit"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (SendToLogit): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/set-arm-environment-variables"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (set-arm-environment-variables): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/set-kubectl"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (set-kubectl): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+          
+  - package-ecosystem: "github-actions"
+    directory: "/set-kubelogin-environment"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (set-kubelogin-environment): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/set-up-environment"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (set-up-environment): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/validate-key-vault-secrets"
+    schedule:
+      interval: "weekly"
+    commit-message: 
+      prefix: "Dependabot (validate-key-vault-secrets): "
+    groups: 
+      gh-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gh-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Dependabot was turned off for this repo, and the existing PRs were for a workflow that no longer exists. This config creates groups to ensure we can update each workflow independently, with their dependencies grouped as a single PR for each directory. There are a number of outdated workflows, so I expect there to be a few PRs raised when we merge.

## Changes proposed in this pull request
dependabot.yml config to organise and turn on dependabot for github actions.

## Guidance to review
I left out the "reviewers" for this because I don't know who owns what. It might be worth us creating a CODEOWNERS file for this repo so the right people can be involved when PRs are raised against actions their team built.

## After merging
We should watch out for the PRs and review/merge them when they are raised.

## Checklist

- [X] I have performed a self-review of my code, including formatting and typos
- [X] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [X] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
