### PR TITLE
[2034] Rename ptr-db-server-name to db-server-name

### DIFF
--- a/backup-postgres/README.md
+++ b/backup-postgres/README.md
@@ -1,7 +1,7 @@
-# Backup Postgres
+# Back up Postgres
 
-Backup an Azure Postgresql server database and upload the backup file to an Azure storage account
-Mainly designed to be used in DR and DR test procedures
+Back up an Azure Postgresql server database and upload the backup file to an Azure storage account
+Designed for scheduled backups as well as disaster recovery procedures
 
 ## Inputs
 - `storage-account`: Name of the Azure storage account for the backup (Required)
@@ -10,7 +10,7 @@ Mainly designed to be used in DR and DR test procedures
 - `cluster`: AKS cluster to use, test or production (Required)
 - `azure-credentials`: A JSON string containing service principle credentials (Required)
 - `backup-file`: Name of the backup file. The file will be compressed and the .gz extension added to this name. (Required)
-- `ptr-db-server-name` : For use if backing up a point in time restored server (Optional)
+- `db-server-name` : Alternate database server (Optional)
 
 ## Example
 

--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -23,8 +23,9 @@ inputs:
   backup-file:
     description: Name of the backup file
     required: true
-  ptr-db-server-name:
-    description: Name of the PTR postgres server
+  db-server-name:
+    description: |
+      Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
     required: false
 
 runs:
@@ -75,8 +76,8 @@ runs:
     - name: Create compressed backup for aks env database
       shell: bash
       run: |
-        if [[ -n "${{ inputs.ptr-db-server-name }}" ]]; then
-          ./konduit.sh -s ${{ inputs.ptr-db-server-name }} -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
+        if [[ -n "${{ inputs.db-server-name }}" ]]; then
+          ./konduit.sh -s ${{ inputs.db-server-name }} -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
         else
           ./konduit.sh -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
         fi


### PR DESCRIPTION
## Context
Rename the argument in the backup DB workflow for clarity as it can be applied to any database server, not specifically point-in-time.

## Changes proposed in this pull request
Rename argument and update description

## Guidance to review
https://github.com/DFE-Digital/teaching-record-system/actions/runs/11167470580

## After merging
The argument must be updated in ITTMS and TRS workflows

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
