### PR TITLE
Add max caching option to build-docker-image

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -7,7 +7,19 @@ It creates 2 tags:
 - Commit SHA to identify this build uniquely
 - Branch name to allow reusing the cached layers from the registry
 
+If caching is enabled via reuse-cache, the caching used depends on the setting of max-cache
+- max-cache = false, (default) then it will use inline caching (min level). Cache of the final stage only is exported with the image,
+  see https://docs.docker.com/build/cache/backends/inline/ and it will use the docker build driver https://docs.docker.com/build/builders/drivers/docker/
+- max-cache = true, then it will use registry caching (max level). Cache for all stages is exported separate to the image,
+  see https://docs.docker.com/build/cache/backends/registry/ and it will use the docker-container build driver https://docs.docker.com/build/builders/drivers/docker-container/
+
+max-cache=true is preferred for multi-stage builds.
+
+Note that the cache hit ratio for a workflow running build can be seen on the workflow summary page.
+
 Optionally (recommended) scan the image for vulnerabilities using [Snyk](https://snyk.io/).
+
+A service that uses this action with reuse-cache = true, should also have a cache refresh workflow that has reuse-cache = false that runs weekly and on-demand. This is required to refresh the underlying cache so it picks up any underlying image changes.
 
 ## Inputs
 - `github-token`: Default Github token retrieved via secrets. GITHUB_TOKEN or PAT with permission to the repository (Required)
@@ -17,6 +29,7 @@ Optionally (recommended) scan the image for vulnerabilities using [Snyk](https:/
 - `context`: Path used as file context for Docker. If not set, the git repository is cloned using the same git reference as the workflow and used as context.
 - `target`: The target stage to build of a multi-stage build
 - `docker-repository`: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers. Defaults to current Github repository name.
+- `max-cache`: Set to true to use maximum cache level when reuse-cache is set. Defaults to minimum (false)
 
 ## Outputs
 - `tag`: Tag uniquely generated for this build (Currently long commit SHA)

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -23,6 +23,11 @@ inputs:
     type: string
   target:
     description: The target stage to build of a multi-stage build
+  max-cache:
+    description: Use max caching for build
+    default: false
+    type: boolean
+    required: false
 
 outputs:
   tag:
@@ -77,9 +82,9 @@ runs:
       run: |
         echo "tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
-    - name: Build docker image using cache
+    - name: Build docker image using inline cache
       uses: docker/build-push-action@v6
-      if: inputs.reuse-cache
+      if: ${{ ( inputs.reuse-cache == 'true' && inputs.max-cache == 'false' ) }}
       with:
         tags: |
           ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
@@ -100,9 +105,9 @@ runs:
       env:
         DOCKER_BUILD_RECORD_UPLOAD: false
 
-    - name: Build docker image without reusing cache
+    - name: Build docker image without reusing inline cache
       uses: docker/build-push-action@v6
-      if: ${{! inputs.reuse-cache}}
+      if: ${{ ( inputs.reuse-cache == 'false' && inputs.max-cache == 'false' ) }}
       with:
         tags: |
           ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
@@ -110,6 +115,53 @@ runs:
         push: false
         load: true
         cache-to: type=inline
+        build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
+        file: ${{ inputs.dockerfile-path }}
+        context: ${{ inputs.context }}
+        target: ${{ inputs.target }}
+      env:
+        DOCKER_BUILD_RECORD_UPLOAD: false
+
+    - name: Set up Docker Buildx
+      if: ${{ inputs.max-cache == 'true' }}
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build docker image using max cache
+      uses: docker/build-push-action@v6
+      if: ${{ ( inputs.reuse-cache == 'true' && inputs.max-cache == 'true' ) }}
+      with:
+        tags: |
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
+        push: false
+        load: true
+        cache-to: |
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}-buildcache,mode=max
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}-buildcache,mode=max
+        cache-from: |
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:main-buildcache
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}-buildcache
+        build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
+        file: ${{ inputs.dockerfile-path }}
+        context: ${{ inputs.context }}
+        target: ${{ inputs.target }}
+        labels: |
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+      env:
+        DOCKER_BUILD_RECORD_UPLOAD: false
+
+    - name: Build docker image without reusing max cache
+      uses: docker/build-push-action@v6
+      if: ${{ ( inputs.reuse-cache == 'false' && inputs.max-cache == 'true' ) }}
+      with:
+        tags: |
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
+        push: false
+        load: true
+        cache-to: |
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}-buildcache,mode=max
+          type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}-buildcache,mode=max
         build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
         file: ${{ inputs.dockerfile-path }}
         context: ${{ inputs.context }}


### PR DESCRIPTION
## Context
Add registry max caching option to build-docker-image 

## Changes proposed in this pull request
Updates to build-docker-image workflow and readme
- add max-cache input

## Guidance to review
single stage docker image
- max cache (reuse-cache=true,max-cache=true): https://github.com/DFE-Digital/get-a-teacher-relocation-payment/actions/runs/11383642707
- break max cache: (reuse-cache=false,max-cache=true): https://github.com/DFE-Digital/get-a-teacher-relocation-payment/actions/runs/11383931620

multi stage docker image
- max cache (reuse-cache=true,max-cache=true): https://github.com/DFE-Digital/itt-mentor-services/actions/runs/11386288131
- break max cache: (reuse-cache=false,max-cache=true): https://github.com/DFE-Digital/itt-mentor-services/actions/runs/11388279565

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
