### PR TITLE
CI-CD for domains

### DIFF
--- a/deploy-domains-env/README.md
+++ b/deploy-domains-env/README.md
@@ -1,0 +1,36 @@
+# Deploy Domains Environment
+
+Deploy the Environment Domains
+
+## Inputs
+- `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
+- `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
+- `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
+- `environment`: the name of the environment for the domains (Required)
+- `healthcheck` : Health check path, without first / e.g. 'healthcheck/all' (Optional)
+- `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
+- `terraform-base` : Name of the base terraform path (default: 'terraform/domains/environment')
+
+## Example
+
+```yaml
+jobs:
+  main:
+    ...
+    permissions:
+      id-token: write # Required for OIDC authentication to Azure
+      ...
+
+    steps:
+      - name: Deploy Domains Environment
+        id: deploy_domains_env
+        uses: DFE-Digital/github-actions/deploy-domain-env@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          environment: test
+          healthcheck: healthcheck/all
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          terraform-base: terraform/domains/environment
+```

--- a/deploy-domains-env/action.yml
+++ b/deploy-domains-env/action.yml
@@ -1,0 +1,78 @@
+name: Deploy Domains Infrastructure
+description: Deploy Domains for infrastructure
+
+inputs:
+  azure-client-id:
+    description: Azure service principal or managed identity client ID when using OIDC
+    required: false
+    default: ''
+  azure-subscription-id:
+    description: Azure service principal or managed identity subscription ID when using OIDC
+    required: false
+    default: ''
+  azure-tenant-id:
+    description: Azure service principal or managed identity tenant ID when using OIDC
+    required: false
+    default: ''
+  environment:
+    description: the name of the environment for the domains.
+    required: true
+  slack-webhook:
+    description: Name of the slack webhook
+    required: false
+  healthcheck:
+    description: Health check path
+    required: false
+  terraform-base:
+    description: Path to the terraform files
+    required: false
+    default: "terraform/domains/environment_domains"
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set Environment variables
+      id: set_env_var
+      shell: bash
+      run: |
+        terraform_version=$(awk '/{/{f=/^terraform/;next}f' ${{ inputs.terraform-base }}/terraform.tf | grep -o [0-9\.]*)
+        echo "TERRAFORM_VERSION=$terraform_version" >> $GITHUB_ENV
+
+    - name: Use Terraform ${{ env.TERRAFORM_VERSION }}
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ env.TERRAFORM_VERSION }}
+        terraform_wrapper: false
+
+    - name: Set ARM environment variables
+      uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      with:
+        azure-client-id: ${{ inputs.azure-client-id }}
+        azure-tenant-id: ${{ inputs.azure-tenant-id }}
+        azure-subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - name: Terraform Domains Environment
+      shell: bash
+      run: |
+        make ci ${{ inputs.environment }} domains-apply
+
+    - name: Run healthcheck
+      shell: bash
+      run: |
+        hosted_zones=$(terraform -chdir=${{ inputs.terraform-base }} output -json hosted_zones | jq -r '.[]')
+        for url in $hosted_zones; do
+          echo "Check health for $url/${{ inputs.healthcheck }}..."
+          curl -sS --fail "$url/${{ inputs.healthcheck }}" > /dev/null
+        done
+
+    - name: Slack Notification
+      if: failure()
+      uses: rtCamp/action-slack-notify@master
+      env:
+        SLACK_COLOR: failure
+        SLACK_TITLE: Failure deploying domains environment to ${{ inputs.environment }}
+        SLACK_MESSAGE: Failure deploying domains environment to ${{ inputs.environment }}
+        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}

--- a/deploy-domains-infra/README.md
+++ b/deploy-domains-infra/README.md
@@ -1,0 +1,32 @@
+# Deploy Domains Infrastructure
+
+Deploy the infrastructure Domains
+
+## Inputs
+- `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
+- `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
+- `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
+- `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
+- `terraform-base` : Name of the base terraform path (default: 'terraform/domains/infrastructure')
+
+## Example
+
+```yaml
+jobs:
+  main:
+    ...
+    permissions:
+      id-token: write # Required for OIDC authentication to Azure
+      ...
+
+    steps:
+      - name: Deploy Domains Infrastructure
+        id: deploy_domains_infra
+        uses: DFE-Digital/github-actions/deploy-domain-infra@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          terraform-base: terraform/domains/infrastructure
+```

--- a/deploy-domains-infra/action.yml
+++ b/deploy-domains-infra/action.yml
@@ -1,0 +1,63 @@
+name: Deploy Domains Infrastructure
+description: Deploy Domains for infrastructure
+
+inputs:
+  azure-client-id:
+    description: Azure service principal or managed identity client ID when using OIDC
+    required: false
+    default: ''
+  azure-subscription-id:
+    description: Azure service principal or managed identity subscription ID when using OIDC
+    required: false
+    default: ''
+  azure-tenant-id:
+    description: Azure service principal or managed identity tenant ID when using OIDC
+    required: false
+    default: ''
+  slack-webhook:
+    description: Name of the slack webhook
+    required: false
+  terraform-base:
+    description: Path to the terraform files
+    required: false
+    default: "terraform/domains/infrastructure"
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set Environment variables
+      id: set_env_var
+      shell: bash
+      run: |
+        terraform_version=$(awk '/{/{f=/^terraform/;next}f' ${{ inputs.terraform-base }}/terraform.tf | grep -o [0-9\.]*)
+        echo "TERRAFORM_VERSION=$terraform_version" >> $GITHUB_ENV
+
+    - name: Use Terraform ${{ env.TERRAFORM_VERSION }}
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ env.TERRAFORM_VERSION }}
+        terraform_wrapper: false
+
+    - name: Set ARM environment variables
+      uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      with:
+        azure-client-id: ${{ inputs.azure-client-id }}
+        azure-tenant-id: ${{ inputs.azure-tenant-id }}
+        azure-subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - name: Terraform Domains Infrastructure
+      shell: bash
+      run: |
+        make ci domains-infra-apply
+
+    - name: Slack Notification
+      if: failure()
+      uses: rtCamp/action-slack-notify@master
+      env:
+        SLACK_COLOR: failure
+        SLACK_TITLE: Failure deploying domains infrastructure
+        SLACK_MESSAGE: Failure deploying domains infrastructure
+        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}


### PR DESCRIPTION
## Context
Actions for CI-CD for domains 

## Changes proposed in this pull request
actions to deploy infrastructure domains and environment domains callable from workflows

initially these actions just do terraform plan for testing.  Will be changed to apply before merge

[Implement CI/CD for domains on all services](https://trello.com/c/unElJf6I/2168-implement-ci-cd-for-domains-on-all-services)

## Guidance to review
tested by using the itt-mentor-services to run workflows to call these actions. 

see PR https://github.com/DFE-Digital/itt-mentor-services/pull/1287

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
