### PR TITLE
Use lower case build image name

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -31,10 +31,10 @@ inputs:
 outputs:
   tag:
     description: Docker image unique tag
-    value: ${{ steps.set-tag-output.outputs.tag }}
+    value: ${{ steps.set-outputs.outputs.tag }}
   image:
     description: Reference to the built image name with the tag suitable for Kubernetes
-    value: ${{ inputs.docker-repository }}:${{ steps.set-tag-output.outputs.tag }}
+    value: ${{ steps.set-outputs.outputs.repo }}:${{ steps.set-outputs.outputs.tag }}
 
 runs:
   using: composite
@@ -75,11 +75,12 @@ runs:
         echo "BRANCH_TAG=main" >> $GITHUB_ENV
         echo "IMAGE_TAG=$(date +%s)" >> $GITHUB_ENV
 
-    - name: Set tag output
-      id: set-tag-output
+    - name: Set outputs
+      id: set-outputs
       shell: bash
       run: |
         echo "tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+        echo "repo=${DOCKER_REPOSITORY}" >> "$GITHUB_OUTPUT"
 
     - name: Build docker image using inline cache
       uses: docker/build-push-action@v6


### PR DESCRIPTION
## Context
build-docker-image returns an image output that contains upper case letters, causing deploy to fail
e.g. DFE-Digital instead of dfe-digital

## Changes proposed in this pull request
use lower case DOCKER_REPOSITORY for the output

## Guidance to review
https://github.com/DFE-Digital/find-a-lost-trn/actions/runs/12810348606 uses this branch

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
