### PR TITLE
Fix install-postgres-client for ubuntu 24

### DIFF
--- a/install-postgres-client/action.yml
+++ b/install-postgres-client/action.yml
@@ -12,7 +12,7 @@ runs:
     shell: bash
     id: install_postgres_client
     run: |
-      sudo apt-get --purge remove postgresql-client-14
+      sudo dpkg --status postgresql-client-14 2>&1 && sudo apt-get --purge remove postgresql-client-14 || true
       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
       RELEASE=$(lsb_release -cs)
       echo "deb http://apt.postgresql.org/pub/repos/apt/ ${RELEASE}"-pgdg main | sudo tee  /etc/apt/sources.list.d/pgdg.list


### PR DESCRIPTION
## Context
install-postgres-client fails after runner update to ubuntu 24
it contains a hardcoded delete for the postgres 14 client which doesn't exist on the new version

## Changes proposed in this pull request
Only delete if it exists

## Guidance to review
https://github.com/DFE-Digital/schools-experience/actions/runs/12828486968

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
