### PR TITLE
[2201] Add namespace to database action examples

### DIFF
--- a/backup-postgres/README.md
+++ b/backup-postgres/README.md
@@ -10,6 +10,7 @@ Federated credentials must be set up to allow the action to authenticate to Azur
 - `storage-account`: Name of the Azure storage account for the backup (Required)
 - `resource-group`: Azure resource group of the storage account (Required)
 - `app-name`: Name of the aks app deployment (Required)
+- `namespace`: Namespace where the app is deployed. Required when role is not cluster admin.
 - `cluster`: AKS cluster to use, test or production (Required)
 - `azure-credentials`: A JSON string containing service principal credentials e.g. {"client_id": "x", "client_secret": "x", "subscription_id": "x", "tenant_id": "x"}
 - `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
@@ -38,6 +39,7 @@ jobs:
           resource-group: s189t01-app-rg
           app-name: myservice-qa
           cluster: test
+          namespace: ${{ env.NAMESPACE }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/restore-postgres-backup/README.md
+++ b/restore-postgres-backup/README.md
@@ -10,6 +10,7 @@ Federated credentials must be set up to allow the action to authenticate to Azur
 - `storage-account`: Name of the Azure atorage account that contains the backup (Required)
 - `resource-group`: Azure resource group of the storage account (Required)
 - `app-name`: Name of the aks app deployment (Required)
+- `namespace`: Namespace where the app is deployed. Required when role is not cluster admin.
 - `cluster`: AKS cluster to use, test or production (Required)
 - `azure-credentials`: A JSON string containing service principal credentials e.g. {"client_id": "x", "client_secret": "x", "subscription_id": "x", "tenant_id": "x"}
 - `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
@@ -35,6 +36,7 @@ jobs:
           resource-group: s189t01-app-rg
           app-name: myservice-qa
           cluster: test
+          namespace: ${{ env.NAMESPACE }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Context
The namespace is required when the user is not cluster admin. It is the standard so it should be explicit in the documentation.

## Changes proposed in this pull request
Add the namespace to the readmes

## Guidance to review
Review readmes, compare with implementation in ITTMS

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
