### PR TITLE
[2221] Use git data for all docker build tags

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -26,7 +26,7 @@ A service that uses this action with reuse-cache = true, should also have a cach
 - `snyk-token`: Snyk token for image vulnerability scanning (Default = none)
 - `reuse-cache`: Use previously built docker image layers to improve build time. Set to false to refresh image (Default = true)
 - `dockerfile-path`: Relative path to the Dockerfile (Default = ./Dockerfile)
-- `context`: Path used as file context for Docker. If not set, the git repository is cloned using the same git reference as the workflow and used as context.
+- `context`: Path used as file context for Docker (Default is '.')
 - `target`: The target stage to build of a multi-stage build
 - `docker-repository`: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers. Defaults to current Github repository name.
 - `max-cache`: Set to true to use maximum cache level when reuse-cache is set. Defaults to minimum (false)
@@ -39,6 +39,8 @@ A service that uses this action with reuse-cache = true, should also have a cach
 ## Example
 
 ```yaml
+- uses: actions/checkout@v4
+
 - name: Build and push docker image
   uses: DFE-Digital/github-actions/build-docker-image@master
   with:

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -17,8 +17,8 @@ inputs:
     description: Relative path to the Dockerfile (Default = ./Dockerfile)
     default: ./Dockerfile
   context:
-    description: Path used as file context for Docker. If not set, the git repository is cloned using the same git reference as the workflow and used as context.
-    default: ""
+    description: Path used as file context for Docker (Default is '.')
+    default: .
   target:
     description: The target stage to build of a multi-stage build
   max-cache:

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -72,8 +72,11 @@ runs:
       if: github.event_name != 'push' && github.event_name != 'pull_request'
       shell: bash
       run: |
-        echo "BRANCH_TAG=main" >> $GITHUB_ENV
-        echo "IMAGE_TAG=$(date +%s)" >> $GITHUB_ENV
+        GIT_BRANCH=$(git branch --show-current)
+        BRANCH_TAG=${GIT_BRANCH##*/}
+        GIT_COMMIT=$(git rev-parse HEAD)
+        echo "BRANCH_TAG=$BRANCH_TAG" >> $GITHUB_ENV
+        echo "IMAGE_TAG=$GIT_COMMIT" >> $GITHUB_ENV
 
     - name: Set outputs
       id: set-outputs


### PR DESCRIPTION
## Context
When using workflow_dispatch, the branch name was not used and there was no tag with the commit id.

## Changes proposed in this pull request
Automatically read the branch name and commit id from the git context and use them as docker tags

## Guidance to review
See successful runs:
- pull_request: https://github.com/DFE-Digital/early-careers-framework/actions/runs/13053879329
- workflow_dispatch: https://github.com/DFE-Digital/early-careers-framework/actions/runs/13052085495
- schedule: https://github.com/DFE-Digital/find-a-lost-trn/actions/runs/13054046574/job/36420647948

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
