### PR TITLE
Update kubectl client version to 1.31.5

### DIFF
--- a/set-kubectl/action.yaml
+++ b/set-kubectl/action.yaml
@@ -7,4 +7,4 @@ runs:
     - name: Install kubectl
       uses: azure/setup-kubectl@v4
       with:
-        version: 'v1.30.6'
+        version: 'v1.31.5'


### PR DESCRIPTION
## Trello
https://trello.com/c/Gb9zGC6R/2255-aks-upgrade-to-131

## Context
There is a requirement to keep up with the Kubernetes releases for bug fixes and new functionality.

## Changes proposed in this pull request
Update the kubectl client version to match the aks cluster version 1.31.5.

## Guidance to review
kubectl client in github actions should use the updated version.

## Checklist

- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card