### PR TITLE
Move ci before env in Makefile deploy

### DIFF
--- a/deploy-to-aks/action.yml
+++ b/deploy-to-aks/action.yml
@@ -99,7 +99,7 @@ runs:
 
     - name: Terraform apply
       shell: bash
-      run: make ${{ inputs.environment }} ci terraform-apply
+      run: make ci ${{ inputs.environment }} terraform-apply
       env:
         DOCKER_IMAGE_TAG: ${{ inputs.sha }}
         PR_NUMBER: ${{ inputs.pr-number }}


### PR DESCRIPTION
## Context
deploy-to-aks action incorrectly runs ci after env for terraform-apply

## Changes proposed in this pull request
change
make ${{ inputs.environment }} ci terraform-apply
to
make ci ${{ inputs.environment }} terraform-apply

## Guidance to review (from Find-Teachers-For-Research)
$make production ci terraform-plan
Makefile:22: *** Missing CONFIRM_PRODUCTION=yes.  Stop.

$make ci production terraform-plan
make: `ci' is up to date.
make: `production' is up to date.
etc

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
