### PR TITLE
Add sanitise flag backup-postgres

### DIFF
--- a/backup-postgres/README.md
+++ b/backup-postgres/README.md
@@ -19,19 +19,18 @@ Federated credentials must be set up to allow the action to authenticate to Azur
 - `backup-file`: Name of the backup file. The file will be compressed and the .gz extension added to this name. (Required)
 - `slack-webhook`: A slack webhook to send a slack message to the service tech channel (Required)
 - `db-server-name` : Alternate database server (Optional)
+- `exclude-tables`: A string of table names to exclude data from while preserving their schema. Use for creating sanitized backups. (Optional, defaults to '')
 
-## Example
+## Examples
 
+### Regular Backup
 ```yaml
 jobs:
-  main:
-    ...
+  regular-backup:
     permissions:
       id-token: write # Required for OIDC authentication to Azure
-      ...
 
     steps:
-
       - name: Backup postgres
         uses: DFE-Digital/github-actions/backup-postgres@master
         with:
@@ -45,4 +44,28 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           backup-file: backup290224.sql
           slack-webhook: ${{ env.slack-webhook }}
+```
+
+### Backup with Excluded Tables
+```yaml
+jobs:
+  backup-with-excluded-tables:
+    permissions:
+      id-token: write # Required for OIDC authentication to Azure
+
+    steps:
+      - name: Backup postgres with excluded tables
+        uses: DFE-Digital/github-actions/backup-postgres@master
+        with:
+          storage-account: myserviceqabkpsa
+          resource-group: s189t01-app-rg
+          app-name: myservice-qa
+          cluster: test
+          namespace: ${{ env.NAMESPACE }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          backup-file: excluded-tables-backup290224.sql
+          slack-webhook: ${{ env.slack-webhook }}
+          exclude-tables: "users audit_logs sensitive_data"
 ```

--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -42,6 +42,11 @@ inputs:
     description: |
       Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
     required: false
+  exclude-tables:
+    description: |
+      A string of table names to exclude data from while preserving their schema. Use for creating sanitized backups. (Optional, defaults to '')
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -104,7 +109,14 @@ runs:
           DB_SERVER_NAME_ARG="-s ${{ inputs.db-server-name }}"
         fi
 
-        ./konduit.sh ${NAMESPACE_ARG} ${DB_SERVER_NAME_ARG} -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f ${{ inputs.backup-file }}.gz
+        EXCLUDE_OPTS=""
+        if [[ -n "${{ inputs.exclude-tables }}" ]]; then
+          for table in ${{ inputs.exclude-tables }}; do
+            EXCLUDE_OPTS="$EXCLUDE_OPTS --exclude-table-data=$table"
+          done
+        fi
+
+        ./konduit.sh ${NAMESPACE_ARG} ${DB_SERVER_NAME_ARG} -t 7200 -x ${{ inputs.app-name }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password $EXCLUDE_OPTS -f ${{ inputs.backup-file }}.gz
 
     - name: Set Connection String
       shell: bash


### PR DESCRIPTION
Workflow differs to backup-postgres as it retains the schema but excludes specified tables as part of pg_dump, to support the sanitisation process on Github runners for larger databases.

<!-- Delete sections if not required -->

## Context

This is to add a separate workflow to drop large unnecesary tables from the production database for the backups sanitisation process.

## Changes proposed in this pull request

Retain schema and run pg_dump with excluded tables

## Guidance to review

https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/14474795321/job/40597683718 Succesful backup run with sanitisation from new workflow.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
