### PR TITLE
Fix table exclusion in backup GitHub Action

### DIFF
--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -111,7 +111,10 @@ runs:
 
         EXCLUDE_OPTS=""
         if [[ -n "${{ inputs.exclude-tables }}" ]]; then
-          for table in ${{ inputs.exclude-tables }}; do
+          IFS=', ' read -ra TABLES <<< "${{ inputs.exclude-tables }}"
+          for table in "${TABLES[@]}"; do
+            [[ -z "$table" ]] && continue
+            table=$(echo "$table" | xargs)
             EXCLUDE_OPTS="$EXCLUDE_OPTS --exclude-table-data=$table"
           done
         fi


### PR DESCRIPTION
## Context
Bug fix for the `backup-postgres` GitHub Action where the table exclusion feature was not working. Despite specifying tables to exclude in sanitized backup workflows, all data was still being included, creating larger backups and potentially exposing sensitive data.

## Changes proposed in this pull request
Fixed the table exclusion mechanism by:
- Improved bash array handling to properly process the exclude-tables input parameter
- Added support for both comma and space-separated table lists
- Ensured proper construction of pg_dump exclude options

## Guidance to review
- Run the `backup-db-sanitise.yml` workflow manually in a test environment
- Verify that specified tables have their structure preserved but data excluded
- Check that the backup file size is smaller than previous backups
- https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/14743242270/job/41385625453

## Before merging
- Consider running a test in a non-production environment to confirm the fix works as expected
- Ensure this doesn't break any existing workflows that might depend on the current behavior

## After merging
- Monitor the next scheduled sanitized backup run to confirm it works correctly
- Consider updating documentation to clarify how table exclusion should be specified in workflows

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
