### PR TITLE
Revert storage-blob-preview to 1.0.0b1

### DIFF
--- a/delete-review-app/action.yml
+++ b/delete-review-app/action.yml
@@ -103,7 +103,7 @@ runs:
 
     - name: Install Storage Blob Extension
       shell: bash
-      run: az extension add --name storage-blob-preview
+      run: az extension add --name storage-blob-preview --version 1.0.0b1
 
     - name: Set Container Access Key
       shell: bash


### PR DESCRIPTION
## Context
delete-review-app is failing in the state file cleanup as storage-blob-preview has been broken in the latest version 1.0.0b2

## Changes proposed in this pull request
hardcode the extension to the previous working version 1.0.0b1

## Guidance to review
test run https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/16072212755 

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
