### PR TITLE
Upgrade postgres client to v17

### DIFF
--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
       with:
-        version: 16
+        version: 17
 
     - name: Install kubectl
       uses: DFE-Digital/github-actions/set-kubectl@master

--- a/install-postgres-client/action.yml
+++ b/install-postgres-client/action.yml
@@ -13,6 +13,8 @@ runs:
     id: install_postgres_client
     run: |
       sudo dpkg --status postgresql-client-14 2>&1 && sudo apt-get --purge remove postgresql-client-14 || true
+      sudo dpkg --status postgresql-client-15 2>&1 && sudo apt-get --purge remove postgresql-client-15 || true
+      sudo dpkg --status postgresql-client-16 2>&1 && sudo apt-get --purge remove postgresql-client-16 || true
       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
       RELEASE=$(lsb_release -cs)
       echo "deb http://apt.postgresql.org/pub/repos/apt/ ${RELEASE}"-pgdg main | sudo tee  /etc/apt/sources.list.d/pgdg.list

--- a/restore-postgres-backup/action.yml
+++ b/restore-postgres-backup/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
       with:
-        version: 16
+        version: 17
 
     - name: Install kubectl
       uses: DFE-Digital/github-actions/set-kubectl@master


### PR DESCRIPTION
## Context
Services are starting to upgrade to postgres 17, so we need to upgrade the client in our backup and restore actions

## Changes proposed in this pull request
update actions that use postgres 16 client, and change to 17
update the postgres client install action to remove 15 and 16 before installation, as not removing 16 left pg_dump at 16 in testing

## Guidance to review
https://github.com/DFE-Digital/find-a-lost-trn/actions/runs/16624320193

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
