### PR TITLE
Fix lint error in build-docker-image readme

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -56,7 +56,7 @@ e.g.
     context: .
     max-cache: false
     main-branch: "master"
-    docker-repository: ${{ env.DOCKER_REPOSITORY }
+    docker-repository: ${{ env.DOCKER_REPOSITORY }}
 ```
 
 ## Inputs


### PR DESCRIPTION
## Context
minor lint error in the build-docker-image readme

## Changes proposed in this pull request
fix the error

## Guidance to review
see https://github.com/DFE-Digital/github-actions/actions/runs/16627550823/job/47048091366 for the reported error

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
