### PR TITLE
feat(2445): bump kubectl client version - post upgrade

### DIFF
--- a/set-kubectl/action.yaml
+++ b/set-kubectl/action.yaml
@@ -7,4 +7,4 @@ runs:
     - name: Install kubectl
       uses: azure/setup-kubectl@v4
       with:
-        version: 'v1.31.5'
+        version: 'v1.32.6'


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
- keep kubectl client version in step with upgradeded AKS k8s version
https://trello.com/c/suqcFfwt/2445-aks-upgrade-from-1315-to-1326?filter=member%3Apaulsenior26

## Changes proposed in this pull request
- bump kubectl client version from 1.31.5 to 1.32.6

## Guidance to review


## Before merging
N/A

## After merging
N/A

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
