### PR TITLE
Remove Slack webhook requirement

### DIFF
--- a/backup-postgres/README.md
+++ b/backup-postgres/README.md
@@ -17,7 +17,8 @@ Federated credentials must be set up to allow the action to authenticate to Azur
 - `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
 - `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
 - `backup-file`: Name of the backup file. The file will be compressed and the .gz extension added to this name. (Required)
-- `slack-webhook`: A slack webhook to send a slack message to the service tech channel (Required)
+- `slack-webhook`: A slack webhook to send a slack message to the service tech channel (Optional)
+- `teams-webhook-url`: A valid webhook URL for the destination Teams channel (Optional)
 - `db-server-name` : Alternate database server (Optional)
 - `exclude-tables`: A string of table names to exclude data from while preserving their schema. Use for creating sanitized backups. (Optional, defaults to '')
 
@@ -43,7 +44,7 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           backup-file: backup290224.sql
-          slack-webhook: ${{ env.slack-webhook }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
 ```
 
 ### Backup with Excluded Tables
@@ -66,6 +67,6 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           backup-file: excluded-tables-backup290224.sql
-          slack-webhook: ${{ env.slack-webhook }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
           exclude-tables: "users audit_logs sensitive_data"
 ```

--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: true
   slack-webhook:
     description: Name of the slack webhook
-    required: true
+    required: false
   db-server-name:
     description: |
       Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)

--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -70,6 +70,7 @@ e.g.
 - `max-cache`: Set to true to use maximum cache level when reuse-cache is set. Defaults to minimum (false)
 - `extra-cache-repo`: Extra repository to use for cached images (Optional)
 - `slack-webhook`:  A slack webhook to send a slack message to the service tech channel. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
+- `teams-webhook-url`: A valid webhook URL for the destination Teams channel (Optional)
 - `main-branch`: The primary repo branch (Default = 'main')
 - `docker-sha`:  The docker sha (Default is the long commit sha)
 

--- a/deploy-domains-env/README.md
+++ b/deploy-domains-env/README.md
@@ -9,6 +9,7 @@ Deploy the Environment Domains
 - `environment`: the name of the environment for the domains (Required)
 - `healthcheck` : Health check path, without first / e.g. 'healthcheck/all' (Optional)
 - `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
+- `teams-webhook-url` : A valid webhook URL for the destination Teams channel (Optional)
 - `terraform-base` : Name of the base terraform path (default: 'terraform/domains/environment')
 
 ## Example
@@ -31,6 +32,6 @@ jobs:
           azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
           environment: test
           healthcheck: healthcheck/all
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
           terraform-base: terraform/domains/environment
 ```

--- a/deploy-domains-infra/README.md
+++ b/deploy-domains-infra/README.md
@@ -7,6 +7,7 @@ Deploy the infrastructure Domains
 - `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
 - `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
 - `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
+- `teams-webhook-url` : A valid webhook URL for the destination Teams channel (Optional)
 - `terraform-base` : Name of the base terraform path (default: 'terraform/domains/infrastructure')
 
 ## Example
@@ -27,6 +28,6 @@ jobs:
           azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
           azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
           azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
           terraform-base: terraform/domains/infrastructure
 ```

--- a/deploy-to-aks/README.md
+++ b/deploy-to-aks/README.md
@@ -23,6 +23,7 @@ Federated credentials must be set up to allow the action to authenticate to Azur
 - `db-seed`: Run seed command after a deployment. Should only be used for review apps (default: false)
 - `sha`: Commit sha corresponding to the docker image tag to be deployed (Required)
 - `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
+- `teams-webhook-url` : A valid webhook URL for the destination Teams channel (Optional)
 - `smoke-test` : Run an application smoke test after deployment (default: false)
 - `healthcheck` : Health check path, without first / e.g. 'healthcheck/all' (Optional)
 - `terraform-base` : Name of the base terraform path (default: 'terraform/application')

--- a/monitor-postgres-wal/README.md
+++ b/monitor-postgres-wal/README.md
@@ -11,6 +11,7 @@ If logical replication is enabled for a database, then we want to monitor the re
 - `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
 - `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
 - `slack-webhook`: A slack webhook to send a slack message to the service tech channel (Optional)
+- `teams-webhook-url`: A valid webhook URL for the destination Teams channel (Optional)
 - `tf-vars-path` : terraform config file path (default: 'terraform/application/config')
 
 ## Requirements
@@ -65,7 +66,7 @@ jobs:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         environment: ${{ matrix.environment }}
-        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+        teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
         app-name: ${{ env.SERVICE_NAME }}-${{ matrix.environment }}
         tf-vars-path: ${{ env.TF_VARS_PATH }}
 ```

--- a/monitor-postgres-wal/action.yml
+++ b/monitor-postgres-wal/action.yml
@@ -25,7 +25,7 @@ inputs:
     default: ''
   slack-webhook:
     description: Name of the slack webhook
-    required: true
+    required: false
   tf-vars-path:
     description: Path to the terraform config files
     required: false

--- a/send-to-teams-channel/README.md
+++ b/send-to-teams-channel/README.md
@@ -12,7 +12,7 @@ A failure message (status: failure) displays the title in red.
 - `teams-webhook-url`: A valid webhook url for the target teams channel
 - `title`: Title of teams message (default: "Workflow notification")
 - `service`: Name of the service (default: "ServiceNotSet")
-- `messsage`: Message to display (default: "MessageNotSet")
+- `message`: Message to display (default: "MessageNotSet")
 - `status`: Message status, either good (green), warning (amber), or attention (red) (default: "attention")
 - `minimal` : Send full message or minimal. True of False (default: "false")
 - `ghrepo` : Is this workflow running from a github repo?. True of False (default: "true")

--- a/validate-infra/README.md
+++ b/validate-infra/README.md
@@ -34,6 +34,7 @@ Your Makefile's terraform plan commands should use `${DETAILED_EXITCODE}` to inc
     azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
     environment: production
     slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+    teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
 ```
 
 ## Inputs
@@ -48,6 +49,7 @@ Your Makefile's terraform plan commands should use `${DETAILED_EXITCODE}` to inc
 | `terraform-base`        | Path to the terraform files                                    | No       | `cluster/terraform_aks_cluster` |
 | `terraform-version-file`| Name of file containing terraform version                      | No       | `terraform.tf`                  |
 | `slack-webhook`         | Slack webhook URL for notifications                            | No       | -                               |
+| `teams-webhook-url`     | A valid webhook URL for the destination Teams channel          | No       | -                               |
 
 ## Outputs
 
@@ -96,6 +98,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           environment: ${{ github.event.inputs.environment || 'production' }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
 ```
 
 ## Requirements
@@ -107,6 +110,7 @@ jobs:
   - `domains-infra-plan` - Domains infrastructure validation
 - The `ci` and environment targets must be defined in your Makefile
 - (Optional) Slack webhook for notifications
+- (Optional) Teams webhook for notifications
 
 ### Example Makefile Targets
 


### PR DESCRIPTION
## Context

Migration from Slack notifications to Teams notifications means Slack webhook is not a requirement any more.

## Changes proposed in this pull request

* Remove `slack-webhook` requirement from 2 actions
* Update some documentation to reflect the migration to Teams notifications from Slack

## Guidance to review

* Will actions work ok?
* Does documentation make sense? 

## Before merging


## After merging


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
