### PR TITLE
remove postgress client install from Backup postgres

### DIFF
--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -64,11 +64,6 @@ runs:
         tenant-id: ${{ inputs.azure-tenant-id }}
         subscription-id: ${{ inputs.azure-subscription-id }}
 
-    - name: Setup postgres client
-      uses: DFE-Digital/github-actions/install-postgres-client@master
-      with:
-        version: 17
-
     - name: Install kubectl
       uses: DFE-Digital/github-actions/set-kubectl@master
 


### PR DESCRIPTION
## Context
Overnight backup for [apply-for-teacher-training](https://github.com/DFE-Digital/apply-for-teacher-training) is intermittently failing on PGDump, removing redundant Postgress client install which may help and step is redundant anyway.

https://trello.com/c/ycuALlRU/2775-change-apply-backup-to-use-ptr

## Changes proposed in this pull request
Remove step to install Postgress Client on runner

## Guidance to review
Review test runs against this action:
[apply-for-teacher-training](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/25788698778)

