### PR TITLE
2780 - Remove slack notifications

### DIFF
--- a/.github/env.yml
+++ b/.github/env.yml
@@ -4,6 +4,3 @@ DOCKERHUB_REPOSITORY:  dfedigital/get-into-teaching-api
 DOMAIN:                london.cloudapps.digital
 APPLICATION:           Get Into Teaching API Service
 PAAS_APPLICATION_NAME: get-into-teaching-api
-SLACK_FAILURE:         '#ff0000'
-SLACK_SUCCESS:         '#00ff00'
-SLACK_ICON:            https://raw.githubusercontent.com/DFE-Digital/GetIntoTeachingAPI/master/.github/image.png?size=48

--- a/.github/workflows/test-setup-environment-variables.yml
+++ b/.github/workflows/test-setup-environment-variables.yml
@@ -30,6 +30,3 @@ jobs:
           echo DOMAIN=${{ env.DOMAIN }}
           echo APPLICATION=${{ env.APPLICATION }}
           echo PAAS_APPLICATION_NAME=${{ env.PAAS_APPLICATION_NAME }}
-          echo SLACK_FAILURE=${{ env.SLACK_FAILURE }}
-          echo SLACK_SUCCESS=${{ env.SLACK_SUCCESS }}
-          echo SLACK_ICON=${{ env.SLACK_ICON }}

--- a/backup-postgres/README.md
+++ b/backup-postgres/README.md
@@ -17,7 +17,6 @@ Federated credentials must be set up to allow the action to authenticate to Azur
 - `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
 - `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
 - `backup-file`: Name of the backup file. The file will be compressed and the .gz extension added to this name. (Required)
-- `slack-webhook`: A slack webhook to send a slack message to the service tech channel (Optional)
 - `teams-webhook-url`: A valid webhook URL for the destination Teams channel (Optional)
 - `db-server-name` : Alternate database server (Optional)
 - `exclude-tables`: A string of table names to exclude data from while preserving their schema. Use for creating sanitized backups. (Optional, defaults to '')

--- a/backup-postgres/action.yml
+++ b/backup-postgres/action.yml
@@ -35,9 +35,6 @@ inputs:
   backup-file:
     description: Name of the backup file
     required: true
-  slack-webhook:
-    description: Name of the slack webhook
-    required: false
   db-server-name:
     description: |
       Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
@@ -172,16 +169,7 @@ runs:
       env:
         DB_SERVER: ${{ inputs.db-server-name || 'default for app'   }}
 
-    - name: Notify Slack channel on job failure
-      if: failure()
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
-      env:
-        SLACK_USERNAME: CI Deployment
-        SLACK_TITLE: Database ${{ inputs.db-server-name }} backup failure
-        SLACK_MESSAGE: ${{ inputs.app-name }} backup job failed
-        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
-        SLACK_COLOR: failure
-        SLACK_FOOTER: Sent from backup job in backup-db workflow
+
 
     - name: Notify teams channel on job failure
       if: ${{ failure() && inputs.teams-webhook-url != '' }}

--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -69,7 +69,6 @@ e.g.
 - `docker-repository`: Repository name in the container registry. e.g. ghcr.io/dfe-digital/register-trainee-teachers. Defaults to current Github repository name.
 - `max-cache`: Set to true to use maximum cache level when reuse-cache is set. Defaults to minimum (false)
 - `extra-cache-repo`: Extra repository to use for cached images (Optional)
-- `slack-webhook`:  A slack webhook to send a slack message to the service tech channel. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
 - `teams-webhook-url`: A valid webhook URL for the destination Teams channel (Optional)
 - `main-branch`: The primary repo branch (Default = 'main')
 - `docker-sha`:  The docker sha (Default is the long commit sha)

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -29,8 +29,6 @@ inputs:
     description: Use cache from separate repo
     default: ''
     required: false
-  slack-webhook:
-    required: false
   main-branch:
     required: false
     default: "main"
@@ -286,18 +284,6 @@ runs:
           echo 'EXTRA_CACHE_FROM_VAR<<EOF'
           echo EOF
         } >> "$GITHUB_ENV"
-
-    - name: Notify slack channel on job failure
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
-      if: ${{ failure() && github.ref == 'refs/heads/main' && inputs.slack-webhook != '' }}
-      with:
-        SLACK_USERNAME: CI Deployment
-        SLACK_COLOR: failure
-        SLACK_ICON_EMOJI: ':github-logo:'
-        SLACK_TITLE: 'Build failure'
-        SLACK_MESSAGE: ':alert: Build failure on commit ${{env.IMAGE_TAG}} :sadparrot:'
-        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
-        SLACK_FOOTER: Sent from build-docker-image
 
     - name: Notify teams channel on job failure
       if: ${{ failure() && github.ref == 'refs/heads/main' && inputs.teams-webhook-url != '' }}

--- a/deploy-domains-env/README.md
+++ b/deploy-domains-env/README.md
@@ -8,7 +8,6 @@ Deploy the Environment Domains
 - `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
 - `environment`: the name of the environment for the domains (Required)
 - `healthcheck` : Health check path, without first / e.g. 'healthcheck/all' (Optional)
-- `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
 - `teams-webhook-url` : A valid webhook URL for the destination Teams channel (Optional)
 - `terraform-base` : Name of the base terraform path (default: 'terraform/domains/environment')
 

--- a/deploy-domains-env/action.yml
+++ b/deploy-domains-env/action.yml
@@ -17,9 +17,6 @@ inputs:
   environment:
     description: the name of the environment for the domains.
     required: true
-  slack-webhook:
-    description: Name of the slack webhook
-    required: false
   healthcheck:
     description: Health check path
     required: false
@@ -73,15 +70,6 @@ runs:
           echo "Check health for $url/${{ inputs.healthcheck }}..."
           curl -sS --fail "$url/${{ inputs.healthcheck }}" > /dev/null
         done
-
-    - name: Slack Notification
-      if: failure()
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
-      env:
-        SLACK_COLOR: failure
-        SLACK_TITLE: Failure deploying domains environment to ${{ inputs.environment }}
-        SLACK_MESSAGE: Failure deploying domains environment to ${{ inputs.environment }}
-        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
 
     - name: Notify teams channel on job failure
       if: ${{ failure() && inputs.teams-webhook-url != '' }}

--- a/deploy-domains-infra/README.md
+++ b/deploy-domains-infra/README.md
@@ -6,7 +6,6 @@ Deploy the infrastructure Domains
 - `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
 - `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
 - `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
-- `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
 - `teams-webhook-url` : A valid webhook URL for the destination Teams channel (Optional)
 - `terraform-base` : Name of the base terraform path (default: 'terraform/domains/infrastructure')
 

--- a/deploy-domains-infra/action.yml
+++ b/deploy-domains-infra/action.yml
@@ -14,9 +14,6 @@ inputs:
     description: Azure service principal or managed identity tenant ID when using OIDC
     required: false
     default: ''
-  slack-webhook:
-    description: Name of the slack webhook
-    required: false
   terraform-base:
     description: Path to the terraform files
     required: false
@@ -58,15 +55,6 @@ runs:
       shell: bash
       run: |
         make ci domains-infra-apply
-
-    - name: Slack Notification
-      if: failure()
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
-      env:
-        SLACK_COLOR: failure
-        SLACK_TITLE: Failure deploying domains infrastructure
-        SLACK_MESSAGE: Failure deploying domains infrastructure
-        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
 
     - name: Notify teams channel on job failure
       if: ${{ failure() && inputs.teams-webhook-url != '' }}

--- a/deploy-to-aks/README.md
+++ b/deploy-to-aks/README.md
@@ -22,7 +22,6 @@ Federated credentials must be set up to allow the action to authenticate to Azur
 - `pr-number`: Pull Request Number if deploying a review app (Optional)
 - `db-seed`: Run seed command after a deployment. Should only be used for review apps (default: false)
 - `sha`: Commit sha corresponding to the docker image tag to be deployed (Required)
-- `slack-webhook` : A slack webhook to send a slack message to the service tech channel on deploy failure. See https://technical-guidance.education.gov.uk/infrastructure/monitoring/slack/#content (Optional)
 - `teams-webhook-url` : A valid webhook URL for the destination Teams channel (Optional)
 - `smoke-test` : Run an application smoke test after deployment (default: false)
 - `healthcheck` : Health check path, without first / e.g. 'healthcheck/all' (Optional)

--- a/deploy-to-aks/action.yml
+++ b/deploy-to-aks/action.yml
@@ -33,9 +33,6 @@ inputs:
   sha:
     description: Commit sha to be deployed
     required: true
-  slack-webhook:
-    description: Name of the slack webhook
-    required: false
   db-seed:
     description: Run seed command after a deployment. Normally only used for review apps.
     required: false
@@ -164,17 +161,6 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
       run: |
         make ci ${{ inputs.environment }} smoke-test
-
-    - name: Notify Slack channel on job failure
-      if: ${{ failure() && github.ref == 'refs/heads/main' && inputs.slack-webhook != '' }}
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
-      env:
-        SLACK_USERNAME: CI Deployment
-        SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: ${{ inputs.environment }} deployment job failed
-        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
-        SLACK_COLOR: failure
-        SLACK_FOOTER: Sent from deploy-to-aks
 
     - name: Notify teams channel on job failure
       if: ${{ failure() && github.ref == 'refs/heads/main' && inputs.teams-webhook-url != '' }}

--- a/monitor-postgres-wal/README.md
+++ b/monitor-postgres-wal/README.md
@@ -10,7 +10,6 @@ If logical replication is enabled for a database, then we want to monitor the re
 - `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
 - `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
 - `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
-- `slack-webhook`: A slack webhook to send a slack message to the service tech channel (Optional)
 - `teams-webhook-url`: A valid webhook URL for the destination Teams channel (Optional)
 - `tf-vars-path` : terraform config file path (default: 'terraform/application/config')
 

--- a/monitor-postgres-wal/action.yml
+++ b/monitor-postgres-wal/action.yml
@@ -23,9 +23,6 @@ inputs:
     description: Azure service principal or managed identity tenant ID when using OIDC
     required: false
     default: ''
-  slack-webhook:
-    description: Name of the slack webhook
-    required: false
   tf-vars-path:
     description: Path to the terraform config files
     required: false
@@ -120,28 +117,6 @@ runs:
         else
           echo "No replication slot"
         fi
-
-    - name: Notify Slack channel if the replication slot is removed
-      if: ${{ env.REMOVED_SLOT != '' }}
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
-      env:
-        SLACK_USERNAME: DB monitor
-        SLACK_TITLE: Database replication slot removed
-        SLACK_MESSAGE: ${{ inputs.app-name }} replication slot removed
-        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
-        SLACK_COLOR: failure
-        SLACK_FOOTER: Sent from monitor database workflow
-
-    - name: Notify Slack channel on job failure
-      if: failure()
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
-      env:
-        SLACK_USERNAME: DB monitor
-        SLACK_TITLE: Database monitor failure
-        SLACK_MESSAGE: ${{ inputs.app-name }} replication monitor job failed
-        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
-        SLACK_COLOR: failure
-        SLACK_FOOTER: Sent from monitor database workflow
 
     - name: Notify teams channel if the replication slot is removed
       if: ${{ env.REMOVED_SLOT != '' && inputs.teams-webhook-url != '' }}

--- a/set-up-environment/README.md
+++ b/set-up-environment/README.md
@@ -24,11 +24,8 @@ location for these variables.
                     
   - name: Print
     run:  |
-          echo "URL                   = ${{env.SLACK_ICON}}"
           echo "APPLICATION           = ${{env.APPLICATION}}"
           echo "DOCKERHUB_REPOSITORY  = ${{env.DOCKERHUB_REPOSITORY}}"
           echo "DOMAIN                = ${{env.DOMAIN}}"
           echo "PAAS_APPLICATION_NAME = ${{env.PAAS_APPLICATION_NAME}}"
-          echo "SLACK_FAILURE         = ${{env.SLACK_FAILURE}}"
-          echo "SLACK_SUCCESS         = ${{env.SLACK_SUCCESS}}"
 ```

--- a/validate-infra/README.md
+++ b/validate-infra/README.md
@@ -33,7 +33,6 @@ Your Makefile's terraform plan commands should use `${DETAILED_EXITCODE}` to inc
     azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
     environment: production
-    slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
     teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
 ```
 
@@ -50,7 +49,6 @@ Your Makefile's terraform plan commands should use `${DETAILED_EXITCODE}` to inc
 | `terraform-main-ref`    | Git ref (branch/tag/SHA) to use for terraform code             | No       | `main`                          |
 | `terraform-base`        | Path to the terraform files                                    | No       | `cluster/terraform_aks_cluster` |
 | `terraform-version-file`| Name of file containing terraform version                      | No       | `terraform.tf`                  |
-| `slack-webhook`         | Slack webhook URL for notifications                            | No       | -                               |
 | `teams-webhook-url`     | A valid webhook URL for the destination Teams channel          | No       | -                               |
 
 ## Outputs
@@ -101,7 +99,6 @@ jobs:
           environment: ${{ github.event.inputs.environment || 'production' }}
           gcp-wip: ${{ vars.GCP_WIP }}
           gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
 ```
 
@@ -114,7 +111,6 @@ jobs:
   - `domains-plan` - Domains environment validation
   - `domains-infra-plan` - Domains infrastructure validation
 - The `ci` and environment targets must be defined in your Makefile
-- (Optional) Slack webhook for notifications
 - (Optional) Teams webhook for notifications
 
 ### Example Makefile Targets


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Slack notifications are being replaced by Microsoft Teams. Teams integration has already been implemented and Slack config can now be removed.
https://trello.com/c/3SYJkUu7/2780-github-actions-remove-refs-to-slack-channels 

## Changes proposed in this pull request
Remove all configuration for sending notifications to Slack.

## Guidance to review
Confirm that only redundant Slack config has been removed.