### PR TITLE
feat(2689): gitapp reconcile workflow - correct/fix tally (when no stale apps)

### DIFF
--- a/review-app-reconcile/action.yml
+++ b/review-app-reconcile/action.yml
@@ -140,8 +140,13 @@ runs:
           fi
         done
 
-        stale_json=$(printf '%s\n' "${stale_prs[@]}" | jq -R . | jq -s -c .)
-        stale_count=$(echo "$stale_json" | jq 'length')
+        if (( ${#stale_prs[@]} == 0 )); then
+          stale_json="[]"
+        else
+          stale_json=$(printf '%s\n' "${stale_prs[@]}" | jq -R . | jq -s -c .)
+        fi
+
+        stale_count=$(jq 'length' <<< "$stale_json")
 
         echo ""
         echo "Stale PRs:"


### PR DESCRIPTION
### Context

review apps not being cleanly deleted on closure of PR

https://trello.com/c/224583KN/2689-check-delete-review-app

### Changes proposed in this pull request
- correct/fix tally of stale apps when no stale apps are found

### Guidance to review
previous incorrect tally :-
https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/26514210420/job/78086631438

<img width="1303" height="958" alt="Screenshot from 2026-05-27 16-32-23" src="https://github.com/user-attachments/assets/2203b610-3030-477d-96ad-4d547ea57309" />





correct tally:-
https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/26520562392/job/78110073852

<img width="1303" height="958" alt="Screenshot from 2026-05-27 16-23-12" src="https://github.com/user-attachments/assets/cfe4c248-56f8-4505-b3ff-38d2bcd3acc2" />


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally