### PR TITLE
2802 - Github Actions - Individual PRs per update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (repo and reusable workflows): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -25,15 +16,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (AddTrelloComment): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -44,15 +26,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (backup-postgres): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -63,15 +36,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (build-docker-image): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -82,15 +46,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (CheckServicePrincipal): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -101,15 +56,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (CopyPRtoRelease): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -120,15 +66,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (DraftReleaseByTag): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -139,15 +76,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (GenerateReleaseFromSHA): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -158,15 +86,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (install-postgres-client): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -177,15 +96,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (ptr-postgres): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -196,15 +106,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (restore-postgres-backup): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -215,15 +116,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (SendToLogit): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -234,15 +126,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (set-arm-environment-variables): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -253,15 +136,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (set-kubectl): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -272,15 +146,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (set-kubelogin-environment): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -291,15 +156,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (set-up-environment): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"
@@ -310,15 +166,6 @@ updates:
       interval: "weekly"
     commit-message: 
       prefix: "Dependabot (validate-key-vault-secrets): "
-    groups: 
-      gh-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      gh-actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
     labels:
       - "DevOps"
       - "dependencies"


### PR DESCRIPTION
## Context
The reason for this change is to change the dependabot behaviour, so individual updates are treated as separate PRs instead of grouped together.
https://trello.com/c/ji7wTteW/2802-github-actions-dependency-updates 

## Changes proposed in this pull request
This change is implemented by removing the group section of the config, for each of the subdirectories listed in dependabot.yml

## Guidance to review
This has been tested in a separate test repo and confirmed that individual PRs are created for each update (screenshot attached).
<img width="883" height="389" alt="image" src="https://github.com/user-attachments/assets/cb5f7608-3767-4a03-ba4a-49172379db6d" />

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
