### PR TITLE
Add fix-airbyte-replication composite action

### DIFF
--- a/fix-airbyte-lsn/README.md
+++ b/fix-airbyte-lsn/README.md
@@ -1,0 +1,27 @@
+# Fix Airbyte lsn
+
+Workflow to resolve "Saved offset is before replication slot's confirmed lsn" errors for an Airbyte sync
+
+## Inputs
+- `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
+- `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
+- `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
+- `namespace`: Kubernetes namespace where Airbyte is deployed (Required)
+- `cluster`: AKS cluster to use, test or production (Required)
+- `connection-id`: Airbyte connection UUID to reset state for
+- `dry-run`: If true, inspect state only — do not delete
+
+## Examples
+
+```yaml
+- name: Fix Airbyte LSN state
+  uses: DFE-Digital/github-actions/fix-airbyte-lsn@master
+  with:
+    azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+    azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+    azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    namespace: ${{ env.NAMESPACE }}
+    cluster: ${{ env.CLUSTER }}
+    connection-id: ${{ env.CONNECTION_ID }}
+    dry-run: ${{ env.DRY_RUN }}
+```

--- a/fix-airbyte-lsn/action.yml
+++ b/fix-airbyte-lsn/action.yml
@@ -1,0 +1,128 @@
+name: Fix Airbyte LSN Error
+description: Resets the saved LSN state in the Airbyte internal database for a connection, resolving "Saved offset is before replication slot's confirmed lsn" errors
+
+inputs:
+  azure-client-id:
+    description: Azure client ID for OIDC authentication
+    required: true
+  azure-tenant-id:
+    description: Azure tenant ID for OIDC authentication
+    required: true
+  azure-subscription-id:
+    description: Azure subscription ID for OIDC authentication
+    required: true
+  namespace:
+    description: Kubernetes namespace where Airbyte is deployed
+    required: true
+  cluster:
+    description: Cluster name e.g. test or production
+    required: true
+  connection-id:
+    description: Airbyte connection UUID to reset state for
+    required: false
+    default: ''
+  dry-run:
+    description: If true, inspect state only — do not delete
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Install kubectl
+      uses: DFE-Digital/github-actions/set-kubectl@master
+
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-client-id: ${{ inputs.azure-client-id }}
+        azure-tenant-id: ${{ inputs.azure-tenant-id }}
+        azure-subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.azure-client-id }}
+        tenant-id: ${{ inputs.azure-tenant-id }}
+        subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - name: Set up cluster environment variables
+      shell: bash
+      run: |
+        CLUSTER_INPUT="${{ inputs.cluster }}"
+        case $CLUSTER_INPUT in
+          test)
+            echo "cluster_rg=s189t01-tsc-ts-rg" >> $GITHUB_ENV
+            echo "cluster_name=s189t01-tsc-test-aks" >> $GITHUB_ENV
+            ;;
+          production)
+            echo "cluster_rg=s189p01-tsc-pd-rg" >> $GITHUB_ENV
+            echo "cluster_name=s189p01-tsc-production-aks" >> $GITHUB_ENV
+            ;;
+          *)
+            echo "unknown cluster"
+            ;;
+        esac
+
+    - name: Get cluster credentials
+      shell: bash
+      run: |
+        az aks get-credentials --overwrite-existing -g ${{ env.cluster_rg }} -n ${{ env.cluster_name }}
+        kubelogin convert-kubeconfig -l $AAD_LOGIN_METHOD
+
+    - name: Install postgres client
+      uses: DFE-Digital/github-actions/install-postgres-client@master
+
+    - name: Install konduit
+      shell: bash
+      run: |
+        [ ! -f bin/konduit.sh ] && \
+          curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/main/scripts/konduit.sh \
+          -o bin/konduit.sh && chmod +x bin/konduit.sh || true
+
+    - name: Get Airbyte internal DB URL
+      shell: bash
+      run: |
+        DATABASE_URL=$(kubectl -n ${{ inputs.namespace }} get secret/airbyte-db-secrets \
+          --template={{.data.DATABASE_URL}} | base64 -d)
+        echo "::add-mask::$DATABASE_URL"
+        echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
+
+    - name: Inspect current LSN state
+      shell: bash
+      run: |
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          echo "[dry-run] Skipping inspect. No connection-id provided for testing."
+        else
+          bin/konduit.sh -n ${{ inputs.namespace }} -x -u $DATABASE_URL \
+            airbyte-${{ inputs.namespace }}-worker -- \
+            psql -c "SELECT * FROM public.state \
+                     WHERE connection_id = '${{ inputs.connection-id }}' \
+                     ORDER BY created_at DESC;"
+        fi
+
+    - name: Reset saved LSN state
+      shell: bash
+      run: |
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          echo "[dry-run] Skipping DELETE. Would have run:"
+          echo "[dry-run] DELETE FROM public.state WHERE connection_id = '${{ inputs.connection-id }}';"
+        else
+          bin/konduit.sh -n ${{ inputs.namespace }} -x -u $DATABASE_URL \
+            airbyte-${{ inputs.namespace }}-worker -- \
+            psql -c "BEGIN;
+                     DELETE FROM public.state \
+                     WHERE connection_id = '${{ inputs.connection-id }}';
+                     COMMIT;"
+        fi
+
+    - name: Verify state after reset
+      shell: bash
+      run: |
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          echo "[dry-run] Skipping verify. No connection-id provided for testing."
+        else
+          bin/konduit.sh -n ${{ inputs.namespace }} -x -u $DATABASE_URL \
+            airbyte-${{ inputs.namespace }}-worker -- \
+            psql -c "SELECT * FROM public.state \
+                     WHERE connection_id = '${{ inputs.connection-id }}' \
+                     ORDER BY created_at DESC;"
+        fi

--- a/fix-airbyte-replication-slot/README.md
+++ b/fix-airbyte-replication-slot/README.md
@@ -1,0 +1,28 @@
+# Fix Airbyte replication slot
+
+Workflow to recreate the Airbyte replication slot if it has been dropped
+
+## Inputs
+- `azure-client-id`: Azure service principal or managed identity client ID when using OIDC
+- `azure-subscription-id`: Azure service principal or managed identity subscription ID when using OIDC
+- `azure-tenant-id`: Azure service principal or managed identity tenant ID when using OIDC
+- `airbyte-app-name`: Name of the aks app deployment (Required)
+- `namespace`: Kubernetes namespace where Airbyte is deployed (Required)
+- `cluster`: AKS cluster to use, test or production (Required)
+- `connection-id`: Airbyte connection UUID to reset state for
+- `dry-run`: If true, inspect state only — do not delete
+
+## Examples
+
+```yaml
+- name: Fix Airbyte replication slot
+  uses: DFE-Digital/github-actions/fix-airbyte-replication-slot@master
+  with:
+    azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+    azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+    azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    app-name: ${{ env.SERVICE_NAME }}-${{ env.DEPLOY_ENV }}
+    namespace: ${{ env.NAMESPACE }}
+    cluster: ${{ env.CLUSTER }}
+    dry-run: ${{ env.DRY_RUN }}
+```

--- a/fix-airbyte-replication-slot/action.yml
+++ b/fix-airbyte-replication-slot/action.yml
@@ -1,0 +1,126 @@
+name: Fix Airbyte Replication Slot
+description: Checks if the Airbyte replication slot exists on the service database and recreates it if missing
+
+inputs:
+  azure-client-id:
+    description: Azure client ID for OIDC authentication
+    required: true
+  azure-tenant-id:
+    description: Azure tenant ID for OIDC authentication
+    required: true
+  azure-subscription-id:
+    description: Azure subscription ID for OIDC authentication
+    required: true
+  app-name:
+    description: Name of the application pod to tunnel through e.g. register-production
+    required: true
+  namespace:
+    description: Kubernetes namespace where the application is deployed
+    required: true
+  cluster:
+    description: Cluster name e.g. test or production
+    required: true
+  dry-run:
+    description: If true, skip slot creation and only run SELECT queries (safe for testing)
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Install kubectl
+      uses: DFE-Digital/github-actions/set-kubectl@master
+
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-client-id: ${{ inputs.azure-client-id }}
+        azure-tenant-id: ${{ inputs.azure-tenant-id }}
+        azure-subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.azure-client-id }}
+        tenant-id: ${{ inputs.azure-tenant-id }}
+        subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - name: Set up cluster environment variables
+      shell: bash
+      run: |
+        CLUSTER_INPUT="${{ inputs.cluster }}"
+        case $CLUSTER_INPUT in
+          test)
+            echo "cluster_rg=s189t01-tsc-ts-rg" >> $GITHUB_ENV
+            echo "cluster_name=s189t01-tsc-test-aks" >> $GITHUB_ENV
+            ;;
+          production)
+            echo "cluster_rg=s189p01-tsc-pd-rg" >> $GITHUB_ENV
+            echo "cluster_name=s189p01-tsc-production-aks" >> $GITHUB_ENV
+            ;;
+          *)
+            echo "unknown cluster"
+            ;;
+        esac
+
+    - name: Get cluster credentials
+      shell: bash
+      run: |
+        az aks get-credentials --overwrite-existing -g ${{ env.cluster_rg }} -n ${{ env.cluster_name }}
+        kubelogin convert-kubeconfig -l $AAD_LOGIN_METHOD
+
+    - name: Install postgres client
+      uses: DFE-Digital/github-actions/install-postgres-client@master
+
+    - name: Install konduit
+      shell: bash
+      run: |
+        [ ! -f bin/konduit.sh ] && \
+          curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/main/scripts/konduit.sh \
+          -o bin/konduit.sh && chmod +x bin/konduit.sh || true
+
+    - name: Check replication slot status
+      shell: bash
+      run: |
+        bin/konduit.sh -n ${{ inputs.namespace }} -t 60 \
+          ${{ inputs.app-name }} -- \
+          psql -c "SELECT slot_name, active, confirmed_flush_lsn, \
+                   pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal \
+                   FROM pg_replication_slots WHERE slot_name = 'airbyte_slot';"
+
+    - name: Recreate replication slot if it does not exist
+      shell: bash
+      run: |
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          echo "[dry-run] Skipping slot creation. Would have run: pg_create_logical_replication_slot('airbyte_slot', 'pgoutput')"
+          echo "[dry-run] Checking slot existence only:"
+          bin/konduit.sh -n ${{ inputs.namespace }} -t 60 \
+            ${{ inputs.app-name }} -- \
+            psql -c "SELECT CASE
+                       WHEN NOT EXISTS (
+                         SELECT 1 FROM pg_replication_slots WHERE slot_name = 'airbyte_slot'
+                       )
+                       THEN 'Slot does not exist — would recreate in non-dry-run mode'
+                       ELSE 'Slot already exists, no action needed'
+                     END AS dry_run_result;"
+        else
+          cat > /tmp/fix_slot.sql << 'EOF'
+        \set slot_exists false
+        SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = 'airbyte_slot') AS slot_exists \gset
+        \if :slot_exists
+          \echo 'Replication slot "airbyte_slot" already exists.'
+        \else
+          ALTER ROLE CURRENT_USER WITH REPLICATION;
+          SELECT * FROM pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');
+          ALTER ROLE CURRENT_USER WITH NOREPLICATION;
+        \endif
+        EOF
+          bin/konduit.sh -n ${{ inputs.namespace }} -t 60 -i /tmp/fix_slot.sql \
+            ${{ inputs.app-name }} -- psql
+        fi
+
+    - name: Verify replication slot after fix
+      shell: bash
+      run: |
+        bin/konduit.sh -n ${{ inputs.namespace }} -t 60 \
+          ${{ inputs.app-name }} -- \
+          psql -c "SELECT slot_name, active, confirmed_flush_lsn \
+                   FROM pg_replication_slots WHERE slot_name = 'airbyte_slot';"


### PR DESCRIPTION
### Context
Airbyte can lose its Postgres replication slot, requiring a manual process to fix. This composite action provides reusable logic to check if the `airbyte_slot` replication slot exists on a service database and recreate it if missing. It is intended to be called from a minimal workflow in each service repo rather than duplicating the logic across repositories.

### Changes proposed

Added `fix-airbyte-replication/action.yml` as a new composite action. The action accepts the Azure OIDC credentials, app name, namespace and cluster as inputs, then uses konduit to tunnel into the service database and run the necessary SQL to check and recreate the replication slot if it does not exist. A verification step confirms the slot status after the fix.

### Guidance to review

Review that the konduit commands and SQL follow the same patterns as other composite actions in this repo such as `backup-postgres`. The action should only recreate the slot if it does not exist and must never drop an existing slot.

### Before merging

Ensure the corresponding `register-trainee-teachers` PR is ready and waiting  this must be merged first.

### After merging

Merge the `register-trainee-teachers` PR which calls this composite action.

### Checklist
- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have cleaned the commit history
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card