### PR TITLE
feat: sonarscanner-dotnet

### DIFF
--- a/sonarscan-dotnet/README.md
+++ b/sonarscan-dotnet/README.md
@@ -40,10 +40,9 @@ Add the action as a step in your workflow:
 
 ```yaml
 - name: SonarCloud scan
-  uses: DFE-Digital/github-actions/dotnet-sonarscan@main
+  uses: DFE-Digital/github-actions/sonarscan-dotnet@main
   with:
     sonarcloud-project-key: your_project_key
-    sonarcloud-organisation: dfe-digital
     sonarcloud-token: ${{ secrets.SONAR_TOKEN }}
 ```
 
@@ -55,16 +54,15 @@ Add the action as a step in your workflow:
 - name: Download merged coverage
   uses: actions/download-artifact@v4
   with:
-    name: merged-coverage-report
-    path: merged-coverage-reports
+    name: coverage
+    path: coverage-reports
 
 - name: SonarCloud scan
-  uses: DFE-Digital/github-actions/dotnet-sonarscan@main
+  uses: DFE-Digital/github-actions/sonarscan-dotnet@main
   with:
     sonarcloud-project-key: your_project_key
-    sonarcloud-organisation: dfe-digital
     sonarcloud-token: ${{ secrets.SONAR_TOKEN }}
-    coverage-report-path: merged-coverage-reports/SonarQube.xml
+    coverage-report-path: coverage-reports/SonarQube.xml
 ```
 
 ---
@@ -73,11 +71,11 @@ Add the action as a step in your workflow:
 
 ```yaml
 - name: SonarCloud scan
-  uses: DFE-Digital/github-actions/dotnet-sonarscan@main
+  uses: DFE-Digital/github-actions/sonarscan-dotnet@main
   with:
     sonarcloud-project-key: your_project_key
     sonarcloud-token: ${{ secrets.SONAR_TOKEN }}
-    use-global-json: "true"
+    use-global-json: true
 ```
 
 If `use-global-json` is true, a `global.json` file must exist in the repository.

--- a/sonarscan-dotnet/README.md
+++ b/sonarscan-dotnet/README.md
@@ -26,13 +26,13 @@ It:
 - `dotnet-version`: .NET SDK version used when not using global.json
 - `dotnet-tool-restore`: Runs `dotnet tool restore` when true
 - `java-distribution`: Java distribution used by SonarScanner (e.g. zulu, temurin, microsoft) (Default: zulu)
-- `java-version`: Java version used by SonarScanner (Default: 17)
-- `sonarcloud-project-key`: SonarCloud project key (Required)
-- `sonarcloud-organisation`: SonarCloud organisation (Required, Default: dfe-digital)
-- `sonarcloud-token`: SonarCloud authentication token (Required)
-- `sonarcloud-url`: SonarCloud server URL (Default: https://sonarcloud.io)
+- `java-version`: Java version used by SonarScanner
+- `sonarcloud-project-key`: SonarCloud project key
+- `sonarcloud-organisation`: SonarCloud organisation (Default: dfe-digital)
+- `sonarcloud-token`: SonarCloud authentication token
+- `sonarcloud-url`: SonarCloud server URL
 - `sonarscan-args`: Additional SonarScanner arguments (e.g. /d:sonar.*)
-- `use-global-json`: Uses global.json to select the SDK (Default: false)
+- `use-global-json`: Uses global.json to select the SDK
 
 ## Usage
 

--- a/sonarscan-dotnet/README.md
+++ b/sonarscan-dotnet/README.md
@@ -1,0 +1,113 @@
+# Dotnet SonarCloud Scan
+
+A reusable GitHub Action for running SonarCloud analysis on .NET applications by wrapping a build with SonarScanner.
+
+---
+
+## Purpose
+
+This action provides a consistent way to integrate SonarCloud analysis into .NET pipelines without duplicating configuration.
+
+It:
+
+- Configures the .NET SDK
+- Ensures the SonarScanner is available
+- Runs SonarScanner begin
+- Executes the build command
+- Runs SonarScanner end
+
+---
+
+## Inputs
+
+- `build-command`: Command used to build the application. Executed between SonarScanner begin and end steps.
+- `coverage-report-path`: Path to a Sonar-compatible coverage report (e.g. SonarQube.xml)
+- `coverage-exclusions`: Comma-separated list of coverage exclusion patterns
+- `dotnet-version`: .NET SDK version used when not using global.json
+- `dotnet-tool-restore`: Runs `dotnet tool restore` when true
+- `java-distribution`: Java distribution used by SonarScanner (e.g. zulu, temurin, microsoft) (Default: zulu)
+- `java-version`: Java version used by SonarScanner (Default: 17)
+- `sonarcloud-project-key`: SonarCloud project key (Required)
+- `sonarcloud-organisation`: SonarCloud organisation (Required, Default: dfe-digital)
+- `sonarcloud-token`: SonarCloud authentication token (Required)
+- `sonarcloud-url`: SonarCloud server URL (Default: https://sonarcloud.io)
+- `sonarscan-args`: Additional SonarScanner arguments (e.g. /d:sonar.*)
+- `use-global-json`: Uses global.json to select the SDK (Default: false)
+
+## Usage
+
+Add the action as a step in your workflow:
+
+```yaml
+- name: SonarCloud scan
+  uses: DFE-Digital/github-actions/dotnet-sonarscan@main
+  with:
+    sonarcloud-project-key: your_project_key
+    sonarcloud-organisation: dfe-digital
+    sonarcloud-token: ${{ secrets.SONAR_TOKEN }}
+```
+
+---
+
+## Example: with coverage
+
+```yaml
+- name: Download merged coverage
+  uses: actions/download-artifact@v4
+  with:
+    name: merged-coverage-report
+    path: merged-coverage-reports
+
+- name: SonarCloud scan
+  uses: DFE-Digital/github-actions/dotnet-sonarscan@main
+  with:
+    sonarcloud-project-key: your_project_key
+    sonarcloud-organisation: dfe-digital
+    sonarcloud-token: ${{ secrets.SONAR_TOKEN }}
+    coverage-report-path: merged-coverage-reports/SonarQube.xml
+```
+
+---
+
+## Example: using global.json
+
+```yaml
+- name: SonarCloud scan
+  uses: DFE-Digital/github-actions/dotnet-sonarscan@main
+  with:
+    sonarcloud-project-key: your_project_key
+    sonarcloud-token: ${{ secrets.SONAR_TOKEN }}
+    use-global-json: "true"
+```
+
+If `use-global-json` is true, a `global.json` file must exist in the repository.
+
+---
+
+## Example: custom build command
+
+```yaml
+with:
+  build-command: dotnet build YourSolution.sln --no-restore --no-incremental
+```
+
+## Dependabot and SONAR_TOKEN
+
+SonarCloud analysis requires a valid `SONAR_TOKEN` to publish results.
+
+Dependabot pull requests do not have access to repository secrets by default. This means:
+
+- SonarCloud analysis will fail if the action runs on Dependabot PRs without access to `SONAR_TOKEN`
+- This is expected behaviour in GitHub and not specific to this action
+
+### Recommended approach
+
+Control execution in the calling workflow to avoid running the scan when secrets are not available:
+
+```yaml
+- name: SonarCloud scan
+  if: github.actor != 'dependabot[bot]'
+  uses: DFE-Digital/github-actions/dotnet-sonarscan@main
+  with:
+    sonarcloud-project-key: your_project_key
+    sonarcloud-token: ${{ secrets.SONAR_TOKEN }}

--- a/sonarscan-dotnet/action.yaml
+++ b/sonarscan-dotnet/action.yaml
@@ -1,0 +1,140 @@
+name: "Dotnet SonarCloud Scan"
+description: "Runs SonarCloud analysis by wrapping a dotnet build with SonarScanner begin and end steps."
+
+inputs:
+  build-command:
+    description: "The command used to build the application. Executed between SonarScanner begin and end steps."
+    required: true
+    default: "dotnet build"
+
+  coverage-report-path:
+    description: "Path to the Sonar-compatible coverage report (e.g. SonarQube.xml)."
+    required: false
+
+  coverage-exclusions:
+    description: "Comma-separated list of coverage exclusion patterns."
+    required: false
+    default: "**/*.html,**/*.json,**/wwwroot/**,**/Migrations/**,**/bin/**,**/obj/**"
+
+  dotnet-version:
+    description: "The .NET SDK version to install when not using global.json."
+    required: false
+    default: "8.0.x"
+
+  dotnet-tool-restore:
+    description: "If true, runs dotnet tool restore."
+    required: false
+    default: "true"
+
+  java-distribution:
+    description: "Java distribution (e.g. zulu, temurin, microsoft) for SonarScanner."
+    required: false
+    default: "zulu"
+
+  java-version:
+    description: "Java version used by SonarScanner."
+    required: false
+    default: "17"
+
+  sonarcloud-project-key:
+    description: "SonarCloud project key."
+    required: true
+
+  sonarcloud-organisation:
+    description: "SonarCloud organisation."
+    required: true
+    default: "dfe-digital"
+
+  sonarcloud-token:
+    description: "SonarCloud authentication token."
+    required: true
+
+  sonarcloud-url:
+    description: "The SonarCloud server URL (typically https://sonarcloud.io)."
+    required: false
+    default: "https://sonarcloud.io"
+
+  sonarscan-args:
+    description: "Additional SonarScanner arguments."
+    required: false
+    default: ""
+
+  use-global-json:
+    description: "Use global.json to select SDK."
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup .NET (global.json)
+      if: inputs.use-global-json == 'true'
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Setup .NET (fallback to dotnet-version)
+      if: inputs.use-global-json != 'true'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+
+    - name: Ensure SonarScanner is available
+      if: inputs.dotnet-tool-restore == 'true'
+      shell: bash
+      run: |
+        set -e
+
+        echo "Ensuring dotnet-sonarscanner is available..."
+
+        # Attempt to restore tools
+        dotnet tool restore || true
+
+        # Check if scanner is usable
+        if dotnet tool run dotnet-sonarscanner --version > /dev/null 2>&1; then
+          echo "Using dotnet-sonarscanner from tool manifest or existing install."
+        else
+          echo "Installing dotnet-sonarscanner globally..."
+          dotnet tool install --global dotnet-sonarscanner
+          export PATH="$PATH:$HOME/.dotnet/tools"
+        fi
+
+    - name: Setup Java for SonarScanner
+      uses: actions/setup-java@v5
+      with:
+        distribution: ${{ inputs.java-distribution }}
+        java-version: ${{ inputs.java-version }}
+
+    - name: Begin Sonar
+      shell: bash
+      run: |
+        set -e
+        
+        echo "Starting SonarCloud analysis for ${{ inputs.sonarcloud-project-key }}"
+
+        if [ -n "${{ inputs.coverage-report-path }}" ]; then
+          COVERAGE_ARG="/d:sonar.coverageReportPaths=${{ inputs.coverage-report-path }}"
+        else
+          COVERAGE_ARG=""
+        fi
+
+        dotnet tool run dotnet-sonarscanner begin \
+          /o:"${{ inputs.sonarcloud-organisation }}" \
+          /k:"${{ inputs.sonarcloud-project-key }}" \
+          /d:sonar.host.url="${{ inputs.sonarcloud-url }}" \
+          /d:sonar.token="${{ inputs.sonarcloud-token }}" \
+          ${COVERAGE_ARG} \
+          /d:sonar.coverage.exclusions="${{ inputs.coverage-exclusions }}" \
+          /d:sonar.scanner.skipJreProvisioning=true \
+          ${{ inputs.sonarscan-args }}
+
+    - name: Build
+      run: ${{ inputs.build-command }}
+      shell: bash
+
+    - name: End Sonar
+      if: always()
+      shell: bash
+      run: |
+        dotnet tool run dotnet-sonarscanner end \
+          /d:sonar.token="${{ inputs.sonarcloud-token }}"

--- a/sonarscan-dotnet/action.yaml
+++ b/sonarscan-dotnet/action.yaml
@@ -109,7 +109,11 @@ runs:
       shell: bash
       run: |
         set -e
-        
+
+        # Mask the SonarCloud token so it is redacted from any logs
+        echo "SONAR_TOKEN=${{ inputs.sonarcloud-token }}" >> $GITHUB_ENV
+        echo "::add-mask::$SONAR_TOKEN"
+
         echo "Starting SonarCloud analysis for ${{ inputs.sonarcloud-project-key }}"
 
         if [ -n "${{ inputs.coverage-report-path }}" ]; then
@@ -122,7 +126,7 @@ runs:
           /o:"${{ inputs.sonarcloud-organisation }}" \
           /k:"${{ inputs.sonarcloud-project-key }}" \
           /d:sonar.host.url="${{ inputs.sonarcloud-url }}" \
-          /d:sonar.token="${{ inputs.sonarcloud-token }}" \
+          /d:sonar.token="$SONAR_TOKEN" \
           ${COVERAGE_ARG} \
           /d:sonar.coverage.exclusions="${{ inputs.coverage-exclusions }}" \
           /d:sonar.scanner.skipJreProvisioning=true \
@@ -137,4 +141,4 @@ runs:
       shell: bash
       run: |
         dotnet tool run dotnet-sonarscanner end \
-          /d:sonar.token="${{ inputs.sonarcloud-token }}"
+          /d:sonar.token="$SONAR_TOKEN"

--- a/sonarscan-dotnet/action.yaml
+++ b/sonarscan-dotnet/action.yaml
@@ -91,7 +91,7 @@ runs:
         dotnet tool restore || true
 
         # Check if scanner is usable
-        if dotnet tool run dotnet-sonarscanner --version > /dev/null 2>&1; then
+        if dotnet tool list --local | grep -q dotnet-sonarscanner; then
           echo "Using dotnet-sonarscanner from tool manifest or existing install."
         else
           echo "Installing dotnet-sonarscanner globally..."

--- a/sonarscan-dotnet/action.yaml
+++ b/sonarscan-dotnet/action.yaml
@@ -111,8 +111,10 @@ runs:
         set -e
 
         # Mask the SonarCloud token so it is redacted from any logs
-        echo "SONAR_TOKEN=${{ inputs.sonarcloud-token }}" >> $GITHUB_ENV
-        echo "::add-mask::$SONAR_TOKEN"
+        
+        TOKEN="${{ inputs.sonarcloud-token }}"
+        echo "::add-mask::$TOKEN"
+        echo "SONAR_TOKEN=$TOKEN" >> $GITHUB_ENV
 
         echo "Starting SonarCloud analysis for ${{ inputs.sonarcloud-project-key }}"
 

--- a/sonarscan-dotnet/action.yaml
+++ b/sonarscan-dotnet/action.yaml
@@ -128,7 +128,7 @@ runs:
           /o:"${{ inputs.sonarcloud-organisation }}" \
           /k:"${{ inputs.sonarcloud-project-key }}" \
           /d:sonar.host.url="${{ inputs.sonarcloud-url }}" \
-          /d:sonar.token="$SONAR_TOKEN" \
+          /d:sonar.token="$TOKEN" \
           ${COVERAGE_ARG} \
           /d:sonar.coverage.exclusions="${{ inputs.coverage-exclusions }}" \
           /d:sonar.scanner.skipJreProvisioning=true \


### PR DESCRIPTION
## Context

Introduce a reusable GitHub composite action for running SonarCloud analysis on .NET applications.

This replaces the need for each repository to configure SonarScanner setup, SDK handling, Java setup, and begin/build/end wrapping individually.

As EducationProviderRegistry has 3 repositories that will use Sonar, this seemed a good time to do this. We have a working example on [GetInformationAboutPupils](https://github.com/DFE-Digital/get-information-about-pupils/blob/7fb7dd06f7cff457cf6169f1cae661a23acbedcc/.github/workflows/web-application-cicd.yml#L352). 

There are [many dotnet projects](https://github.com/search?q=org%3ADFE-Digital%20dotnet-sonarscanner&type=code) that consume the cli scanner in `DFE-Digital`

## Changes proposed in this pull request
```yaml

## Example consumer

- name: SonarCloud scan
  uses: DFE-Digital/github-actions/sonarscan-dotnet@main
  with:
    sonarcloud-project-key: your_project_key
    sonarcloud-token: ${{ secrets.SONAR_TOKEN }}
    coverage-report-path: merged-coverage-reports/SonarQube.xml
```

## Guidance to review

Example consumer on GIAP

- [PR](https://github.com/DFE-Digital/get-information-about-pupils/pull/698)
- [Action](https://github.com/DFE-Digital/get-information-about-pupils/actions/runs/27012167090/job/79720124079?pr=698#step:6:829) 

<img width="1351" height="588" alt="image" src="https://github.com/user-attachments/assets/29ae9e4f-081a-4e05-8325-19aab0a517e1" />

## After merging

[] Adopt across other projects
[] Java17 deprecation warning from July 26...

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] ~~I have attached the pull request to the trello card~~
