### PR TITLE
2802 - Updated marocchino workflow step

### DIFF
--- a/.github/workflows/dependabot-tracking.yml
+++ b/.github/workflows/dependabot-tracking.yml
@@ -20,6 +20,6 @@ jobs:
       # SHA: e31e87e03dd19038e411e38ae27cbad084a90661
       - uses: rtCamp/action-slack-notify@v2.3.3
 
-      # marocchino/sticky-pull-request-comment v2.9.4
-      # SHA: 773744901bac0e8cbb5a0dc842800d45e9b2b405
-      - uses: marocchino/sticky-pull-request-comment@v2.9.4
+      # marocchino/sticky-pull-request-comment v3.0.4
+      # SHA: 0ea0beb66eb9baf113663a64ec522f60e49231c0
+      - uses: marocchino/sticky-pull-request-comment@v3.0.4

--- a/delete-review-app/action.yml
+++ b/delete-review-app/action.yml
@@ -95,7 +95,7 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
 
     - name: Post Pull Request Comment
-      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
       with:
         header: aks
         message: |

--- a/deploy-to-aks/action.yml
+++ b/deploy-to-aks/action.yml
@@ -144,7 +144,7 @@ runs:
 
     - name: Post comment to Pull Request ${{ inputs.pr-number }}
       if: inputs.pr-number != ''
-      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
       with:
         header: aks
         message: |


### PR DESCRIPTION
## Context
This is a manual PR for a dependabot update, the reason for this is that the update is for a step that is SHA pinned, so dependabot will not include additional changes to the workflow files that use it or update the comments.

## Changes proposed in this pull request
This change will update the marocchino/sticky-pull-request-comment step from version 2.9.4 to the latest which is 3.0.4. The additional changes that were not included in the original dependabot PR are:

- Updated comments to align with the version update in dependabot-tracking.yml
- Updated SHAs and version comments in the following files:
   delete-review-app/action.yml
   deploy-to-aks/action.yml

## Guidance to review
1. Check against the original PR to ensure it is being updated to the same version: https://github.com/DFE-Digital/github-actions/pull/177
2. Confirm that the new SHA is correct for version 3.0.4 in the marocchino releases: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
3. Review the changes in the test PR that was created to confirm the comment function works as expected: https://github.com/DFE-Digital/github-actions/pull/183
Note the changes that were made to .github/workflows/test-setup-environment-variables.yml to add a comment to a PR.
Confirm the dependabot comment on the PR matches the added step in the above file.

## Before merging
Confirm the above information is correct.

## After merging
Do not merge any of the other PRs mentioned above, this is the only PR that requires a merge to main, once this is done the other PRs will be closed.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
