### PR TITLE
2683 - Parameterise docker image string construction and update actio…

### DIFF
--- a/.github/workflows/dependabot-tracking.yml
+++ b/.github/workflows/dependabot-tracking.yml
@@ -20,6 +20,6 @@ jobs:
       # SHA: e31e87e03dd19038e411e38ae27cbad084a90661
       - uses: rtCamp/action-slack-notify@v2.3.3
 
-      # marocchino/sticky-pull-request-comment v2.9.4
-      # SHA: 773744901bac0e8cbb5a0dc842800d45e9b2b405
-      - uses: marocchino/sticky-pull-request-comment@v2.9.4
+      # marocchino/sticky-pull-request-comment v3.0.4
+      # SHA: 0ea0beb66eb9baf113663a64ec522f60e49231c0
+      - uses: marocchino/sticky-pull-request-comment@v3.0.4

--- a/.github/workflows/reusable-workflow-sast.yml
+++ b/.github/workflows/reusable-workflow-sast.yml
@@ -122,7 +122,7 @@ jobs:
     if: ${{ (github.actor != 'dependabot[bot]') && (inputs.force_semgrep == true || needs.test-visibility.outputs.visibility == 'private') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Run the "semgrep scan" command on the command line of the docker image.
       - run: semgrep scan --config auto --sarif --sarif-output=semgrep.sarif --force-color
@@ -161,7 +161,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
         

--- a/.github/workflows/test-setup-environment-variables.yml
+++ b/.github/workflows/test-setup-environment-variables.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Environment Variables
         uses: ./set-up-environment

--- a/delete-review-app/action.yml
+++ b/delete-review-app/action.yml
@@ -95,7 +95,7 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
 
     - name: Post Pull Request Comment
-      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
       with:
         header: aks
         message: |

--- a/deploy-to-aks/action.yml
+++ b/deploy-to-aks/action.yml
@@ -144,7 +144,7 @@ runs:
 
     - name: Post comment to Pull Request ${{ inputs.pr-number }}
       if: inputs.pr-number != ''
-      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
       with:
         header: aks
         message: |

--- a/validate-infra/action.yml
+++ b/validate-infra/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: "terraform.tf"
   validation-plan:
-    description: 'Which validation plan to execute: aks-infra, domains-env, or domains-infra'
+    description: "Which validation plan to execute: aks-infra, domains-env, or domains-infra"
     required: false
   teams-webhook-url:
     description: Valid webhook for the destination teams channel
@@ -42,6 +42,18 @@ inputs:
   service:
     description: Name of service, used in teams notification messages
     required: false
+  target-branch:
+    description: Branch name to compare to production
+    required: false
+    default: "main"
+  image-prefix:
+    description: Prefix for the docker image name
+    required: false
+    default: ""
+  sha-type:
+    description: Long or 7 character short
+    required: false
+    default: "long"
 
 outputs:
   cluster_drift_detected:
@@ -59,15 +71,28 @@ runs:
 
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.target-branch != '' && inputs.target-branch || 'main' }}
 
     - name: Set environment variables
       shell: bash
       run: |
         # Get the current commit SHA (works for any ref)
-        GIT_COMMIT=$(git rev-parse HEAD)
-        echo "IMAGE_TAG=$GIT_COMMIT" >> $GITHUB_ENV
-        echo "DOCKER_IMAGE_TAG=$GIT_COMMIT" >> $GITHUB_ENV
+        SHA_TYPE="${{ inputs.sha-type }}"
+        echo "sha-type input = $SHA_TYPE"
+        echo "target-branch = ${{ inputs.target-branch }}"
+        echo "image-prefix = ${{ inputs.image-prefix }}"
+
+        if [[ "$SHA_TYPE" == "long" ]]; then
+          GIT_COMMIT="$(git rev-parse HEAD)"
+        else
+          GIT_COMMIT="$(git rev-parse --short=7 HEAD)"
+        fi
+
+        echo "IMAGE_TAG=${{ inputs.image-prefix }}$GIT_COMMIT" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE_TAG=${{ inputs.image-prefix }}$GIT_COMMIT" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_NAME=${{ github.event_name }}" >> $GITHUB_ENV
         echo "Using commit SHA: $GIT_COMMIT"
 
     - name: Azure login


### PR DESCRIPTION
## Context

It was proving impossible to manage validate-infra in some services as we needed access to github.event_name in the make logic for terraform-init.

## Changes proposed in this pull request

Along with the additional  
`echo "GITHUB_EVENT_NAME=${{ github.event_name }}" >> $GITHUB_ENV`
we took the opportunity to add additional variables target-branch and sha-type. These default to main and long respectively. 
In `Set environment variables` the logic around setting the GIT_COMMIT variable has been strengthened.

We've also increased the actions/checkout version to version 6 as this will soon be required.

## Guidance to review

These cannot be reviewed independently. They must be pulled by a local calidate infra workflow.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
