### PR TITLE
2683 - Parameterise docker image string construction and update actio…

### DIFF
--- a/validate-infra/action.yml
+++ b/validate-infra/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: "terraform.tf"
   validation-plan:
-    description: 'Which validation plan to execute: aks-infra, domains-env, or domains-infra'
+    description: "Which validation plan to execute: aks-infra, domains-env, or domains-infra"
     required: false
   teams-webhook-url:
     description: Valid webhook for the destination teams channel
@@ -42,6 +42,18 @@ inputs:
   service:
     description: Name of service, used in teams notification messages
     required: false
+  target-branch:
+    description: Branch name to compare to production
+    required: false
+    default: "main"
+  image-prefix:
+    description: Prefix for the docker image name
+    required: false
+    default: ""
+  sha-type:
+    description: Long or 7 character short
+    required: false
+    default: "long"
 
 outputs:
   cluster_drift_detected:
@@ -59,15 +71,28 @@ runs:
 
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.target-branch != '' && inputs.target-branch || 'main' }}
 
     - name: Set environment variables
       shell: bash
       run: |
         # Get the current commit SHA (works for any ref)
-        GIT_COMMIT=$(git rev-parse HEAD)
+        SHA_TYPE="${{ inputs.sha-type }}"
+        echo "sha-type input = $SHA_TYPE"
+        echo "target-branch = ${{ inputs.target-branch }}"
+        echo "image-prefix = ${{ inputs.image-prefix }}"
+
+        if [[ "$SHA_TYPE" == "long" ]]; then
+          GIT_COMMIT="${{ inputs.image-prefix }}$(git rev-parse HEAD)"
+        else
+          GIT_COMMIT="${{ inputs.image-prefix }}$(git rev-parse --short=7 HEAD)"
+        fi
+
         echo "IMAGE_TAG=$GIT_COMMIT" >> $GITHUB_ENV
         echo "DOCKER_IMAGE_TAG=$GIT_COMMIT" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_NAME=${{ github.event_name }}" >> $GITHUB_ENV
         echo "Using commit SHA: $GIT_COMMIT"
 
     - name: Azure login


### PR DESCRIPTION
## Context

Update the GitHub central action so that docker image strings can be defined differently in different services.

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

## Changes proposed in this pull request

New inputs, target-branch, image-prefix, sha-type.
actions/checkout changed to version 6
New bash run commands to calculate how to construct the Docker image string depending on the 3 inputs described above.

## Guidance to review

You can run the "Validate Infra" workflow if it already exists for the service. You can point it at the branch but that will always produce a false positive as the docker image will be different for main/master and the branch. This will produce a workflow Teams message in SD Infra Alerts.

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/b2f7861d-33c5-4382-ab95-1b73e580fc86" />

There are 3 jobs in the workflow, AKS infrastructure, Domains infrastructure and Domains environment. The workflow card will show which job to look at in the bottom left corner (Infrastructure in the image above). You can click the Workflow Run button to go to the correct run.
The jobs must show a green tick not a red cross.
You can alter any value in the terraform production.tfvars.json in your branch to check that the terraform plan picks up those changes, remembering that the docker image is a false positive.

If the workflow does not exist you will have to test locally using the relative make terraform-plan command for the service. 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
