### PR TITLE
2683 - npq-registration uses DOCKER_IMAGE

### DIFF
--- a/validate-infra/action.yml
+++ b/validate-infra/action.yml
@@ -91,6 +91,7 @@ runs:
         fi
 
         echo "IMAGE_TAG=$GIT_COMMIT" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE=$GIT_COMMIT" >> $GITHUB_ENV
         echo "DOCKER_IMAGE_TAG=$GIT_COMMIT" >> $GITHUB_ENV
         echo "GITHUB_EVENT_NAME=${{ github.event_name }}" >> $GITHUB_ENV
         echo "Using commit SHA: $GIT_COMMIT"


### PR DESCRIPTION
## Context

Update the GitHub central action so that docker image strings can be defined differently in different services.

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

## Changes proposed in this pull request

npq-registration use DOCKER_IMAGE as their variable so this has been added to the bash script in the Set environment variables step.

## Guidance to review

You can run the "Validate Infra" workflow if it already exists for the service. You can point it at the branch but that will always produce a false positive as the docker image will be different for main/master and the branch. This will produce a workflow Teams message in SD Infra Alerts.

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/b2f7861d-33c5-4382-ab95-1b73e580fc86" />

There are 3 jobs in the workflow, AKS infrastructure, Domains infrastructure and Domains environment. The workflow card will show which job to look at in the bottom left corner (Infrastructure in the image above). You can click the Workflow Run button to go to the correct run.
The jobs must show a green tick not a red cross.
You can alter any value in the terraform production.tfvars.json in your branch to check that the terraform plan picks up those changes, remembering that the docker image is a false positive.

If the workflow does not exist you will have to test locally using the relative make terraform-plan command for the service. 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
